### PR TITLE
Cleanup thread references after video processing

### DIFF
--- a/routes/video_routes.py
+++ b/routes/video_routes.py
@@ -82,7 +82,7 @@ async def predict_video_endpoint(request: VideoRequest):
     def processamento_em_thread():
         try:
             print(f"[THREAD] Iniciando a chamada para contar_gado_em_video para: {video_name_on_server}")
-            
+
             # Chama a função de contagem e armazena o resultado retornado
             resultado = contar_gado_em_video(
                 video_path=os.path.join(UPLOAD_FOLDER, video_name_on_server),
@@ -93,24 +93,33 @@ async def predict_video_endpoint(request: VideoRequest):
                 target_classes=request.target_classes,
                 line_position_ratio=request.line_position_ratio,
             )
-            
+
             # Se 'resultado' não for None (ou seja, o processamento foi bem-sucedido e não foi cancelado)...
             if resultado is not None:
                 # ...chama .finalizar() para atualizar o banco de dados com os resultados.
-                print(f"[THREAD] contagem_video retornou um resultado. Finalizando o progresso no banco de dados...")
+                print(
+                    f"[THREAD] contagem_video retornou um resultado. Finalizando o progresso no banco de dados..."
+                )
                 progresso_manager.finalizar(video_name_on_server, resultado)
             else:
                 # Se resultado for None, o erro ou cancelamento já foi tratado dentro de contar_gado_em_video
                 # e o status no banco de dados já foi atualizado para finalizado=True.
-                print(f"[THREAD] contagem_video retornou None. O status já deve estar como erro ou cancelado.")
+                print(
+                    f"[THREAD] contagem_video retornou None. O status já deve estar como erro ou cancelado."
+                )
 
         except Exception as e:
             import traceback
-            print(f"[THREAD ERRO FATAL] Um erro inesperado ocorreu na thread para {video_name_on_server}: {e}")
+            print(
+                f"[THREAD ERRO FATAL] Um erro inesperado ocorreu na thread para {video_name_on_server}: {e}"
+            )
             traceback.print_exc()
             progresso_manager.erro(video_name_on_server, f"Erro crítico na thread: {str(e)}")
+        finally:
+            # Remover referência à thread após o término para liberar memória
+            processos_em_andamento.pop(video_name_on_server, None)
 
-    thread = threading.Thread(target=processamento_em_thread)
+    thread = threading.Thread(target=processamento_em_thread, daemon=True)
     thread.start()
     processos_em_andamento[video_name_on_server] = thread
 
@@ -127,5 +136,5 @@ async def progresso_endpoint(video_name: str):
 @router.get("/cancelar-processamento/{video_name}")
 async def cancelar_endpoint(video_name: str):
     if progresso_manager.cancelar(video_name):
-      return {"message": f"Solicitação de cancelamento para {video_name} enviada."}
+        return {"message": f"Solicitação de cancelamento para {video_name} enviada."}
     return {"message": f"Não foi possível cancelar ou o processo para {video_name} não está ativo."}


### PR DESCRIPTION
## Summary
- Remove finished threads from `processos_em_andamento`
- Mark worker threads as daemon to avoid blocking server shutdown

## Testing
- `python -m py_compile routes/video_routes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab3d70c50483219b7377d6cc4aa4e4