### PR TITLE
refactor: replace prints with logging

### DIFF
--- a/contagemgoogle.py
+++ b/contagemgoogle.py
@@ -5,6 +5,9 @@ from ultralytics import YOLO
 from collections import defaultdict
 import numpy as np
 from typing import Optional, Tuple, List, Dict, Any
+import logging
+
+logger = logging.getLogger(__name__)
 
 # --- Funções auxiliares (copiadas do seu projeto) ---
 LINE_HORIZONTAL, LINE_VERTICAL = "horizontal", "vertical"
@@ -19,19 +22,19 @@ def get_line_and_direction_config(orientation_code: str, width: int, height: int
         return LINE_VERTICAL, MOVE_LR if orientation_code == 'E' else MOVE_RL, ((line_pos_value, 0), (line_pos_value, height)), line_pos_value
 
 def contar_gado_colab(video_path: str, model_path: str, orientation: str):
-    print(f"Iniciando processamento para o vídeo: {video_path}")
-    print(f"Usando modelo: {model_path}")
+    logger.info(f"Iniciando processamento para o vídeo: {video_path}")
+    logger.info(f"Usando modelo: {model_path}")
 
     try:
         model = YOLO(model_path)
-        print("Modelo YOLO carregado com sucesso.")
+        logger.info("Modelo YOLO carregado com sucesso.")
     except Exception as e:
-        print(f"ERRO: Falha ao carregar o modelo: {e}")
+        logger.error(f"ERRO: Falha ao carregar o modelo: {e}")
         return
 
     cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
-        print(f"ERRO: Não foi possível abrir o vídeo em {video_path}")
+        logger.error(f"ERRO: Não foi possível abrir o vídeo em {video_path}")
         return
 
     width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
@@ -91,13 +94,13 @@ def contar_gado_colab(video_path: str, model_path: str, orientation: str):
 
         frame_idx += 1
         if frame_idx % 30 == 0:
-          print(f"Processando frame {frame_idx}...")
+            logger.debug(f"Processando frame {frame_idx}...")
 
     cap.release()
     out.release()
-    print("-" * 20)
-    print(f"Processamento concluído! Contagem final: {total_count}")
-    print(f"Vídeo processado salvo como: {output_filename}")
+    logger.info("-" * 20)
+    logger.info(f"Processamento concluído! Contagem final: {total_count}")
+    logger.info(f"Vídeo processado salvo como: {output_filename}")
 
 
 # --- EXECUÇÃO DO TESTE ---

--- a/extract_frames.py
+++ b/extract_frames.py
@@ -1,5 +1,8 @@
 import cv2
 import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 def extract_frames(video_path, output_folder, step=30):
     """
@@ -9,7 +12,7 @@ def extract_frames(video_path, output_folder, step=30):
 
     cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
-        print(f"[ERRO] Não foi possível abrir o vídeo: {video_path}")
+        logger.error(f"[ERRO] Não foi possível abrir o vídeo: {video_path}")
         return
 
     frame_count = 0
@@ -23,10 +26,10 @@ def extract_frames(video_path, output_folder, step=30):
         if frame_count % step == 0:
             frame_filename = os.path.join(output_folder, f"frame_{saved_count:04d}.jpg")
             cv2.imwrite(frame_filename, frame)
-            print(f"[INFO] Frame {frame_count} salvo como {frame_filename}")
+            logger.info(f"[INFO] Frame {frame_count} salvo como {frame_filename}")
             saved_count += 1
 
         frame_count += 1
 
     cap.release()
-    print(f"[INFO] Extração concluída: {saved_count} frames salvos.")
+    logger.info(f"[INFO] Extração concluída: {saved_count} frames salvos.")

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import logging
 from dotenv import load_dotenv
 import os
 
@@ -5,6 +6,13 @@ import os
 # Esta chamada deve ser uma das primeiras linhas do seu ponto de entrada,
 # antes de importar qualquer outro módulo do seu projeto que use essas variáveis.
 load_dotenv()
+
+# Configure logging for the application
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 # --- AGORA, IMPORTE O RESTO DA SUA APLICAÇÃO ---
 from fastapi import FastAPI
@@ -38,9 +46,10 @@ app.include_router(video_routes.router)
 def read_root():
     # Verifica se a variável de DB foi carregada, para debug
     db_url_loaded = bool(os.getenv("DATABASE_URL"))
+    logger.debug("Root endpoint accessed; DATABASE_URL loaded: %s", db_url_loaded)
     return {
         "status": "KYO DAY Backend está no ar!",
-        "database_url_loaded": db_url_loaded
+        "database_url_loaded": db_url_loaded,
     }
 
 # Lembre-se que o comando para rodar é:

--- a/remap.py
+++ b/remap.py
@@ -1,5 +1,8 @@
 import os
 import glob
+import logging
+
+logger = logging.getLogger(__name__)
 
 def remap_class_ids(input_labels_dir, output_labels_dir, class_mapping, new_class_id_gado):
     """
@@ -16,7 +19,7 @@ def remap_class_ids(input_labels_dir, output_labels_dir, class_mapping, new_clas
     """
     if not os.path.exists(output_labels_dir):
         os.makedirs(output_labels_dir)
-        print(f"Diretório de saída criado: {output_labels_dir}")
+        logger.info(f"Diretório de saída criado: {output_labels_dir}")
 
     # Lista de IDs de classe COCO que devem ser convertidos para new_class_id_gado
     # Se class_mapping já contém o mapeamento direto, esta lista pode não ser necessária,
@@ -60,7 +63,7 @@ def remap_class_ids(input_labels_dir, output_labels_dir, class_mapping, new_clas
                         pass # Descarta detecções de classes não mapeadas
 
                 except ValueError:
-                    print(f"Aviso: Linha mal formatada em {label_file_path}: {line.strip()}")
+                    logger.warning(f"Aviso: Linha mal formatada em {label_file_path}: {line.strip()}")
                     modified_lines.append(line.strip()) # Mantém linha mal formatada
         
         if modified_lines: # Salva o arquivo apenas se houver linhas (após descarte ou com modificações)
@@ -73,10 +76,12 @@ def remap_class_ids(input_labels_dir, output_labels_dir, class_mapping, new_clas
             pass
         num_files_processed += 1
 
-    print(f"\nProcessamento concluído.")
-    print(f"Total de arquivos de anotação verificados: {num_files_processed}")
-    print(f"Total de detecções individuais remapeadas para ID '{new_class_id_gado}': {num_detections_remapped}")
-    print(f"Arquivos modificados salvos em: {output_labels_dir}")
+    logger.info("Processamento concluído.")
+    logger.info(f"Total de arquivos de anotação verificados: {num_files_processed}")
+    logger.info(
+        f"Total de detecções individuais remapeadas para ID '{new_class_id_gado}': {num_detections_remapped}"
+    )
+    logger.info(f"Arquivos modificados salvos em: {output_labels_dir}")
 
 if __name__ == '__main__':
     # --- Configuração ---
@@ -106,12 +111,20 @@ if __name__ == '__main__':
 
     # Validação básica dos caminhos
     if not os.path.isdir(INPUT_LABELS_DIRECTORY) or INPUT_LABELS_DIRECTORY == "caminho/para/runs/detect/expN/labels/":
-        print(f"ERRO: O diretório de entrada '{INPUT_LABELS_DIRECTORY}' não existe ou não foi alterado. Por favor, configure corretamente.")
+        logger.error(
+            f"ERRO: O diretório de entrada '{INPUT_LABELS_DIRECTORY}' não existe ou não foi alterado. Por favor, configure corretamente."
+        )
     elif OUTPUT_LABELS_DIRECTORY == "caminho/para/seu_dataset_corrigido/labels/":
-        print(f"AVISO: O diretório de saída '{OUTPUT_LABELS_DIRECTORY}' parece não ter sido alterado do exemplo. Verifique se está correto.")
+        logger.warning(
+            f"AVISO: O diretório de saída '{OUTPUT_LABELS_DIRECTORY}' parece não ter sido alterado do exemplo. Verifique se está correto."
+        )
         remap_class_ids(INPUT_LABELS_DIRECTORY, OUTPUT_LABELS_DIRECTORY, COCO_CLASS_MAPPING_TO_GADO, NEW_GADO_CLASS_ID)
     else:
         remap_class_ids(INPUT_LABELS_DIRECTORY, OUTPUT_LABELS_DIRECTORY, COCO_CLASS_MAPPING_TO_GADO, NEW_GADO_CLASS_ID)
 
-    print("\nLembre-se de copiar as IMAGENS correspondentes para o seu diretório de dataset final e criar o arquivo data.yaml!")
-    print(f"Seu data.yaml deve ter nc: 1 e names: ['gado'] (ou o nome que você escolheu para a classe ID {NEW_GADO_CLASS_ID}).")
+    logger.info(
+        "Lembre-se de copiar as IMAGENS correspondentes para o seu diretório de dataset final e criar o arquivo data.yaml!"
+    )
+    logger.info(
+        f"Seu data.yaml deve ter nc: 1 e names: ['gado'] (ou o nome que você escolheu para a classe ID {NEW_GADO_CLASS_ID})."
+    )

--- a/routes/video_routes.py
+++ b/routes/video_routes.py
@@ -3,6 +3,7 @@ import re
 import shutil
 import threading
 import uuid
+import logging
 from fastapi import APIRouter, UploadFile, File, Form, HTTPException
 from fastapi.responses import JSONResponse
 from typing import Optional, List
@@ -20,6 +21,8 @@ os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 progresso_manager = ProgressoManager()
 processos_em_andamento = {}
 
+logger = logging.getLogger(__name__)
+
 @router.post("/upload-video/")
 async def upload_video_endpoint(file: UploadFile = File(...)):
     """
@@ -30,14 +33,14 @@ async def upload_video_endpoint(file: UploadFile = File(...)):
     unique_filename = f"{uuid.uuid4()}{file_extension}"
     temp_local_path = os.path.join(UPLOAD_FOLDER, unique_filename)
 
-    print(f"[UPLOAD] Recebendo '{file.filename}', salvando como '{unique_filename}'...")
+    logger.info(f"[UPLOAD] Recebendo '{file.filename}', salvando como '{unique_filename}'...")
 
     try:
         with open(temp_local_path, "wb") as buffer:
             shutil.copyfileobj(file.file, buffer)
-        print(f"[UPLOAD] Vídeo salvo temporariamente em: {temp_local_path}")
+        logger.info(f"[UPLOAD] Vídeo salvo temporariamente em: {temp_local_path}")
     except Exception as e:
-        print(f"[UPLOAD ERRO] Falha ao salvar o arquivo temporariamente: {e}")
+        logger.error(f"[UPLOAD ERRO] Falha ao salvar o arquivo temporariamente: {e}")
         raise HTTPException(status_code=500, detail=f"Falha ao salvar o arquivo no servidor: {str(e)}")
 
     # O upload para a HostGator e a limpeza foram movidos para dentro de 'contar_gado_em_video'.
@@ -70,7 +73,7 @@ async def predict_video_endpoint(request: VideoRequest):
         raise HTTPException(status_code=400, detail="Nome de arquivo inválido.")
 
     if progresso_manager.is_processing(video_name_on_server):
-        print(f"[PREDICT AVISO] Vídeo {video_name_on_server} já está sendo processado.")
+        logger.warning(f"[PREDICT AVISO] Vídeo {video_name_on_server} já está sendo processado.")
         return JSONResponse(
             status_code=409,
             content={"status": "em_processamento", "message": "Este vídeo já está sendo processado."}
@@ -81,7 +84,7 @@ async def predict_video_endpoint(request: VideoRequest):
     # --- FUNÇÃO DA THREAD CORRIGIDA ---
     def processamento_em_thread():
         try:
-            print(f"[THREAD] Iniciando a chamada para contar_gado_em_video para: {video_name_on_server}")
+            logger.info(f"[THREAD] Iniciando a chamada para contar_gado_em_video para: {video_name_on_server}")
 
             # Chama a função de contagem e armazena o resultado retornado
             resultado = contar_gado_em_video(
@@ -97,23 +100,21 @@ async def predict_video_endpoint(request: VideoRequest):
             # Se 'resultado' não for None (ou seja, o processamento foi bem-sucedido e não foi cancelado)...
             if resultado is not None:
                 # ...chama .finalizar() para atualizar o banco de dados com os resultados.
-                print(
+                logger.info(
                     f"[THREAD] contagem_video retornou um resultado. Finalizando o progresso no banco de dados..."
                 )
                 progresso_manager.finalizar(video_name_on_server, resultado)
             else:
                 # Se resultado for None, o erro ou cancelamento já foi tratado dentro de contar_gado_em_video
                 # e o status no banco de dados já foi atualizado para finalizado=True.
-                print(
+                logger.info(
                     f"[THREAD] contagem_video retornou None. O status já deve estar como erro ou cancelado."
                 )
 
         except Exception as e:
-            import traceback
-            print(
+            logger.exception(
                 f"[THREAD ERRO FATAL] Um erro inesperado ocorreu na thread para {video_name_on_server}: {e}"
             )
-            traceback.print_exc()
             progresso_manager.erro(video_name_on_server, f"Erro crítico na thread: {str(e)}")
         finally:
             # Remover referência à thread após o término para liberar memória

--- a/test_sftp.py
+++ b/test_sftp.py
@@ -1,6 +1,7 @@
 # Arquivo: test_sftp.py (Corrigido)
 import os
 from dotenv import load_dotenv
+import logging
 
 # --- PASSO 1: CARREGAR AS VARIÁVEIS DE AMBIENTE PRIMEIRO ---
 # Esta chamada precisa acontecer antes de qualquer importação de
@@ -9,6 +10,8 @@ load_dotenv()
 
 # --- PASSO 2: AGORA, IMPORTAR SEUS MÓDULOS ---
 from utils.sftp_handler import upload_file_sftp, download_file_sftp, delete_file_sftp
+
+logger = logging.getLogger(__name__)
 
 def run_sftp_test():
     """Roda um ciclo completo de teste: upload, download e delete."""
@@ -26,33 +29,33 @@ def run_sftp_test():
     # Define um nome para o arquivo quando for baixado de volta
     downloaded_filename = "arquivo_baixado.txt"
     
-    print("--- INICIANDO TESTE SFTP ---")
+    logger.info("--- INICIANDO TESTE SFTP ---")
     
     # 1. Teste de Upload
-    print("\n--- PASSO 1: TESTANDO UPLOAD ---")
+    logger.info("\n--- PASSO 1: TESTANDO UPLOAD ---")
     if upload_file_sftp(local_filename, remote_path):
-        print(">> SUCESSO NO UPLOAD! Verifique o arquivo no Gerenciador de Arquivos da HostGator.")
+        logger.info(">> SUCESSO NO UPLOAD! Verifique o arquivo no Gerenciador de Arquivos da HostGator.")
         
         # 2. Teste de Download (só executa se o upload deu certo)
-        print("\n--- PASSO 2: TESTANDO DOWNLOAD ---")
+        logger.info("\n--- PASSO 2: TESTANDO DOWNLOAD ---")
         if download_file_sftp(remote_path, downloaded_filename):
-            print(f">> SUCESSO NO DOWNLOAD! Verifique o arquivo '{downloaded_filename}' na pasta do seu projeto.")
+            logger.info(f">> SUCESSO NO DOWNLOAD! Verifique o arquivo '{downloaded_filename}' na pasta do seu projeto.")
             # Verifica o conteúdo
             with open(downloaded_filename, 'r') as f:
                 content = f.read()
-                print(f"Conteúdo do arquivo baixado: '{content}'")
+                logger.info(f"Conteúdo do arquivo baixado: '{content}'")
         else:
-            print(">> FALHA NO DOWNLOAD.")
+            logger.error(">> FALHA NO DOWNLOAD.")
 
         # 3. Teste de Delete (limpeza)
-        print("\n--- PASSO 3: TESTANDO DELETE ---")
+        logger.info("\n--- PASSO 3: TESTANDO DELETE ---")
         if delete_file_sftp(remote_path):
-            print(">> SUCESSO AO DELETAR o arquivo remoto.")
+            logger.info(">> SUCESSO AO DELETAR o arquivo remoto.")
         else:
-            print(">> FALHA AO DELETAR o arquivo remoto.")
+            logger.error(">> FALHA AO DELETAR o arquivo remoto.")
             
     else:
-        print(">> FALHA NO UPLOAD. Os outros testes não serão executados.")
+        logger.error(">> FALHA NO UPLOAD. Os outros testes não serão executados.")
 
     # Limpa os arquivos de teste locais
     if os.path.exists(local_filename):
@@ -60,7 +63,7 @@ def run_sftp_test():
     if os.path.exists(downloaded_filename):
         os.remove(downloaded_filename)
 
-    print("\n--- TESTE SFTP FINALIZADO ---")
+    logger.info("\n--- TESTE SFTP FINALIZADO ---")
 
 if __name__ == "__main__":
     run_sftp_test()

--- a/utils/contagem_video.py
+++ b/utils/contagem_video.py
@@ -4,9 +4,12 @@ from ultralytics import YOLO
 from collections import defaultdict
 import numpy as np
 from typing import Optional, Tuple, List, Dict, Any, Callable
+import logging
 
 # Importa as funções SFTP do seu handler
 from utils.sftp_handler import upload_file_sftp, delete_file_sftp
+
+logger = logging.getLogger(__name__)
 
 # --- Constantes para Clareza ---
 LINE_HORIZONTAL: str = "horizontal"
@@ -59,12 +62,14 @@ def get_line_and_direction_config(orientation_code: str, width: int, height: int
         line_type, effective_counting_direction = LINE_DIAGONAL_BCK, MOVE_TR_BL
         line_points, arrow_points = ((0,height),(width,0)), ((3*width//4, height//4), (width//4, 3*height//4))
     else: 
-        print(f"[AVISO get_line_config] Orientação '{orientation_code}' desconhecida. Usando padrão Leste (E).")
+        logger.warning(f"[AVISO get_line_config] Orientação '{orientation_code}' desconhecida. Usando padrão Leste (E).")
         line_type = LINE_VERTICAL; effective_counting_direction = MOVE_LR
         line_pos_value = int(width * line_ratio); line_points = ((line_pos_value, 0), (line_pos_value, height))
         arrow_points = ((line_pos_value - arrow_offset, height // 2), (line_pos_value + arrow_offset, height // 2))
     
-    print(f"[get_line_config] Para '{orientation_code}': tipo={line_type}, dir={effective_counting_direction}")
+    logger.debug(
+        f"[get_line_config] Para '{orientation_code}': tipo={line_type}, dir={effective_counting_direction}"
+    )
     return line_type, effective_counting_direction, line_points, line_pos_value, arrow_points
 
 # !!! ATENÇÃO: ESTA FUNÇÃO PARA DETECÇÃO DIAGONAL É UM ESBOÇO CONCEITUAL. !!!
@@ -95,8 +100,8 @@ def contar_gado_em_video(video_path: str,
     USE_SFTP = os.getenv("USE_SFTP", "false").lower() == "true"
     CREATE_ANNOTATED_VIDEO = os.getenv("CREATE_ANNOTATED_VIDEO", "false").lower() == "true"
     
-    print(f"[CONFIG] Modo SFTP Ativado: {USE_SFTP}")
-    print(f"[CONFIG] Gerar Vídeo Anotado: {CREATE_ANNOTATED_VIDEO}")
+    logger.info(f"[CONFIG] Modo SFTP Ativado: {USE_SFTP}")
+    logger.info(f"[CONFIG] Gerar Vídeo Anotado: {CREATE_ANNOTATED_VIDEO}")
 
     sftp_current_action = ""
     def sftp_progress_callback(bytes_transferred: int, total_bytes: int):
@@ -237,13 +242,13 @@ def contar_gado_em_video(video_path: str,
                 if progresso_manager: progresso_manager.erro(video_name, public_url)
         else:
             public_url = f"Vídeo processado salvo localmente e será deletado."
-            print(f"[INFO] Vídeo processado salvo em {local_output_path} e não será enviado.")
+            logger.info(f"[INFO] Vídeo processado salvo em {local_output_path} e não será enviado.")
 
     if USE_SFTP:
         if CREATE_ANNOTATED_VIDEO and os.path.exists(local_output_path): os.remove(local_output_path)
     if os.path.exists(local_video_path): os.remove(local_video_path)
     if USE_SFTP: delete_file_sftp(remote_video_original)
 
-    print(f"[INFO CONTAGEM] Contagem finalizada: {current_total_count} para {video_name}")
+    logger.info(f"[INFO CONTAGEM] Contagem finalizada: {current_total_count} para {video_name}")
     
     return {"video": video_name, "video_processado": public_url, "total_frames": original_frame_count, "total_count": current_total_count, "por_classe": dict(current_por_classe)}

--- a/utils/gerenciador_progresso.py
+++ b/utils/gerenciador_progresso.py
@@ -2,11 +2,14 @@ import os
 import psycopg2
 import psycopg2.pool
 import time
-import json # Para lidar com a coluna JSONB do resultado
+import json  # Para lidar com a coluna JSONB do resultado
 from typing import Optional, Dict, Any
+import logging
 
 # Pega a URL do banco de dados das variáveis de ambiente carregadas pelo load_dotenv()
 DATABASE_URL = os.getenv("DATABASE_URL")
+
+logger = logging.getLogger(__name__)
 
 # --- Pool de Conexões com o Banco de Dados ---
 pool = None
@@ -14,15 +17,15 @@ try:
     if not DATABASE_URL:
         raise ValueError("A variável de ambiente DATABASE_URL não foi definida.")
     pool = psycopg2.pool.SimpleConnectionPool(1, 5, dsn=DATABASE_URL)
-    print("[DB] Pool de conexões com PostgreSQL criado com sucesso.")
+    logger.info("[DB] Pool de conexões com PostgreSQL criado com sucesso.")
 except Exception as e:
-    print(f"[DB ERRO] Falha CRÍTICA ao criar o pool de conexões com PostgreSQL: {e}")
-    print("Verifique se o PostgreSQL está rodando e se a DATABASE_URL no seu arquivo .env está correta.")
+    logger.error(f"[DB ERRO] Falha CRÍTICA ao criar o pool de conexões com PostgreSQL: {e}")
+    logger.error("Verifique se o PostgreSQL está rodando e se a DATABASE_URL no seu arquivo .env está correta.")
 
 def create_progress_table_if_not_exists():
     """Garante que a tabela de progresso exista no banco de dados."""
-    if not pool: 
-        print("[DB AVISO] Pool de conexões não disponível. Tabela não pôde ser verificada/criada.")
+    if not pool:
+        logger.warning("[DB AVISO] Pool de conexões não disponível. Tabela não pôde ser verificada/criada.")
         return
     conn = None
     try:
@@ -43,9 +46,9 @@ def create_progress_table_if_not_exists():
                 );
             """)
             conn.commit()
-            print("[DB] Tabela 'video_progress' verificada/criada com sucesso.")
+            logger.info("[DB] Tabela 'video_progress' verificada/criada com sucesso.")
     except Exception as e:
-        print(f"[DB ERRO] Falha ao criar/verificar a tabela 'video_progress': {e}")
+        logger.error(f"[DB ERRO] Falha ao criar/verificar a tabela 'video_progress': {e}")
     finally:
         if conn:
             pool.putconn(conn)
@@ -58,8 +61,8 @@ class ProgressoManager:
 
     def _execute_query(self, query: str, params: tuple = (), fetch: Optional[str] = None):
         """Função auxiliar para executar queries no banco de dados usando o pool."""
-        if not pool: 
-            print("[DB ERRO] Tentativa de executar query sem um pool de conexões válido.")
+        if not pool:
+            logger.error("[DB ERRO] Tentativa de executar query sem um pool de conexões válido.")
             return None
         conn = None
         try:
@@ -72,7 +75,7 @@ class ProgressoManager:
                     return cur.fetchall()
                 conn.commit()
         except Exception as e:
-            print(f"[DB ERRO] Falha na query '{query[:60].strip()}...': {e}")
+            logger.error(f"[DB ERRO] Falha na query '{query[:60].strip()}...': {e}")
             if conn:
                 try: conn.rollback()
                 except psycopg2.InterfaceError: conn = None # Conexão provavelmente já fechada/inválida
@@ -94,7 +97,7 @@ class ProgressoManager:
         """
         params = (video_name, time.time(), "Na fila...", False, False)
         self._execute_query(query, params)
-        print(f"[DB Progresso] Progresso iniciado/resetado para: {video_name}")
+        logger.info(f"[DB Progresso] Progresso iniciado/resetado para: {video_name}")
 
     def is_processing(self, video_name: str) -> bool:
         """Verifica no banco se um vídeo está atualmente em processamento."""
@@ -142,7 +145,7 @@ class ProgressoManager:
         resultado_json = json.dumps(resultado)
         params = (resultado_json, frame_final, video_name)
         self._execute_query(query, params)
-        print(f"[DB Progresso] Finalizado com sucesso para: {video_name}")
+        logger.info(f"[DB Progresso] Finalizado com sucesso para: {video_name}")
 
     def erro(self, video_name: str, mensagem: str):
         """Marca o processamento como finalizado com erro no banco de dados."""
@@ -150,7 +153,7 @@ class ProgressoManager:
         if not self.status(video_name).get("erro"): self.iniciar(video_name) # Garante que a linha exista antes de atualizar
         params = (mensagem, video_name)
         self._execute_query(query, params)
-        print(f"[DB Progresso] Erro registrado para: {video_name}")
+        logger.error(f"[DB Progresso] Erro registrado para: {video_name}")
 
     def status(self, video_name: str) -> Dict[str, Any]:
         """Retorna o status atual de um vídeo do banco de dados."""
@@ -167,6 +170,6 @@ class ProgressoManager:
         if status and not status.get("finalizado"):
             query = "UPDATE video_progress SET cancelado = TRUE, finalizado = TRUE, erro = 'Cancelado pelo usuário.', tempo_restante = 'Cancelado', last_updated = NOW() WHERE video_name = %s;"
             self._execute_query(query, (video_name,))
-            print(f"[DB Progresso] Cancelamento registrado para: {video_name}")
+            logger.info(f"[DB Progresso] Cancelamento registrado para: {video_name}")
             return True
         return False

--- a/utils/sftp_handler.py
+++ b/utils/sftp_handler.py
@@ -2,6 +2,9 @@ import os
 import paramiko
 from stat import S_ISDIR
 from typing import Optional, Tuple, Callable
+import logging
+
+logger = logging.getLogger(__name__)
 
 # Carrega as credenciais das variáveis de ambiente configuradas
 # (no seu .env localmente, ou no dashboard do Render)
@@ -13,16 +16,16 @@ HG_PORT = int(os.getenv("HG_PORT", 22))
 def sftp_connect() -> Optional[Tuple[paramiko.SFTPClient, paramiko.Transport]]:
     """Cria e retorna um cliente SFTP conectado."""
     if not all([HG_HOST, HG_USER, HG_PASS]):
-        print("[SFTP ERRO] Variáveis de ambiente (HG_HOST, HG_USER, HG_PASS) não estão configuradas.")
+        logger.error("[SFTP ERRO] Variáveis de ambiente (HG_HOST, HG_USER, HG_PASS) não estão configuradas.")
         return None, None
     try:
         transport = paramiko.Transport((HG_HOST, HG_PORT))
         transport.connect(username=HG_USER, password=HG_PASS)
         sftp = paramiko.SFTPClient.from_transport(transport)
-        print(f"[SFTP] Conexão com {HG_HOST} bem-sucedida.")
+        logger.info(f"[SFTP] Conexão com {HG_HOST} bem-sucedida.")
         return sftp, transport
     except Exception as e:
-        print(f"[SFTP ERRO] Falha ao conectar: {e}")
+        logger.error(f"[SFTP ERRO] Falha ao conectar: {e}")
         return None, None
 
 def _ensure_remote_dir_exists(sftp: paramiko.SFTPClient, remote_path: str):
@@ -50,7 +53,7 @@ def _ensure_remote_dir_exists(sftp: paramiko.SFTPClient, remote_path: str):
             sftp.stat(current_dir)
         except FileNotFoundError:
             # Se não existe, cria o diretório
-            print(f"[SFTP] Criando diretório remoto: {current_dir}")
+            logger.info(f"[SFTP] Criando diretório remoto: {current_dir}")
             sftp.mkdir(current_dir)
 
 def upload_file_sftp(local_path: str, remote_path: str, progress_callback: Optional[Callable[[int, int], None]] = None) -> bool:
@@ -61,13 +64,13 @@ def upload_file_sftp(local_path: str, remote_path: str, progress_callback: Optio
     try:
         _ensure_remote_dir_exists(sftp, remote_path)
         
-        print(f"[SFTP] Fazendo upload de '{local_path}' para '{remote_path}'...")
+        logger.info(f"[SFTP] Fazendo upload de '{local_path}' para '{remote_path}'...")
         # Passa a função de callback para o método .put() do paramiko
         sftp.put(local_path, remote_path.replace("\\", "/"), callback=progress_callback)
-        print(f"[SFTP] Upload de '{os.path.basename(local_path)}' concluído.")
+        logger.info(f"[SFTP] Upload de '{os.path.basename(local_path)}' concluído.")
         return True
     except Exception as e:
-        print(f"[SFTP ERRO] Falha no upload: {e}"); return False
+        logger.error(f"[SFTP ERRO] Falha no upload: {e}"); return False
     finally:
         if sftp: sftp.close()
         if transport: transport.close()
@@ -78,13 +81,13 @@ def download_file_sftp(remote_path: str, local_path: str, progress_callback: Opt
     if not sftp: return False
     
     try:
-        print(f"[SFTP] Baixando de '{remote_path}' para '{local_path}'...")
+        logger.info(f"[SFTP] Baixando de '{remote_path}' para '{local_path}'...")
         # Passa a função de callback para o método .get() do paramiko
         sftp.get(remote_path.replace("\\", "/"), local_path, callback=progress_callback)
-        print(f"[SFTP] Download de '{os.path.basename(remote_path)}' concluído.")
+        logger.info(f"[SFTP] Download de '{os.path.basename(remote_path)}' concluído.")
         return True
     except Exception as e:
-        print(f"[SFTP ERRO] Falha no download: {e}"); return False
+        logger.error(f"[SFTP ERRO] Falha no download: {e}"); return False
     finally:
         if sftp: sftp.close()
         if transport: transport.close()
@@ -95,15 +98,15 @@ def delete_file_sftp(remote_path: str) -> bool:
     if not sftp: return False
     
     try:
-        print(f"[SFTP] Deletando arquivo remoto: '{remote_path}'...")
+        logger.info(f"[SFTP] Deletando arquivo remoto: '{remote_path}'...")
         sftp.remove(remote_path.replace("\\", "/"))
-        print(f"[SFTP] Arquivo '{os.path.basename(remote_path)}' deletado.")
+        logger.info(f"[SFTP] Arquivo '{os.path.basename(remote_path)}' deletado.")
         return True
     except FileNotFoundError:
-        print(f"[SFTP AVISO] Tentativa de deletar arquivo que não existe: {remote_path}")
+        logger.warning(f"[SFTP AVISO] Tentativa de deletar arquivo que não existe: {remote_path}")
         return True # Considera sucesso se o arquivo já não existe
     except Exception as e:
-        print(f"[SFTP ERRO] Falha ao deletar '{remote_path}': {e}"); return False
+        logger.error(f"[SFTP ERRO] Falha ao deletar '{remote_path}': {e}"); return False
     finally:
         if sftp: sftp.close()
         if transport: transport.close()


### PR DESCRIPTION
## Summary
- configure global logging in `main.py`
- swap `print` statements for `logging` across routes, utilities and scripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ab3fca05f483219d008c8a7c9f018a