### PR TITLE
docs: add contribution guidelines and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Relatar um problema
+title: "[BUG] Descrição resumida"
+labels: bug
+assignees: ''
+---
+
+**Descrição**
+Descreva o bug.
+
+**Reprodução**
+Passos para reproduzir o comportamento:
+1. Vá para '...'
+2. Clique em '...'
+3. Veja o erro
+
+**Comportamento esperado**
+Uma descrição clara do que você esperava que acontecesse.
+
+**Capturas de tela**
+Se aplicável, adicione capturas de tela para ajudar a explicar o problema.
+
+**Ambiente (preencha as seguintes informações):**
+- Sistema operacional:
+- Versão do Python:
+- Navegador (se aplicável):
+- Outras informações:
+
+**Informações adicionais**
+Qualquer outra informação relevante sobre o problema.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Sugerir uma nova funcionalidade
+title: "[FEATURE] Descrição resumida"
+labels: enhancement
+assignees: ''
+---
+
+**Descrição da funcionalidade**
+Descreva a funcionalidade que você gostaria de ver.
+
+**Motivação**
+Explique por que esta funcionalidade seria útil para o projeto.
+
+**Alternativas**
+Liste quaisquer alternativas ou soluções já consideradas.
+
+**Informações adicionais**
+Inclua qualquer informação adicional ou contexto.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Descrição
+Explique as mudanças propostas neste Pull Request.
+
+## Tipo de mudança
+- [ ] Correção de bug
+- [ ] Nova funcionalidade
+- [ ] Alteração de documentação
+- [ ] Tarefa de manutenção
+
+## Checklist
+- [ ] Segui o padrão de commits (`Conventional Commits`).
+- [ ] Executei `flake8` e `pytest`.
+- [ ] Atualizei a documentação, se necessário.
+
+## Issues relacionadas
+Liste aqui as issues relacionadas (ex.: `Fixes #42`).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,68 @@
+# Código de Conduta do Contributor Covenant
+
+## Nossa promessa
+
+Nós, como membros, contribuintes e líderes, nos comprometemos a tornar a participação em nossa comunidade uma experiência livre de assédio para todos, independentemente de idade, tamanho corporal, deficiência visível ou invisível, etnia, características sexuais, identidade e expressão de gênero, nível de experiência, educação, status socioeconômico, nacionalidade, aparência pessoal, raça, casta, cor, religião ou identidade e orientação sexual.
+
+Comprometemo-nos a agir e interagir de maneiras que contribuam para uma comunidade aberta, acolhedora, diversificada, inclusiva e saudável.
+
+## Nossos padrões
+
+Exemplos de comportamento que contribuem para um ambiente positivo:
+
+- Demonstração de empatia e gentileza com outras pessoas;
+- Respeito por opiniões, pontos de vista e experiências diferentes;
+- Feedback construtivo e receptivo;
+- Aceitação de responsabilidade e pedido de desculpas aos afetados por nossos erros;
+- Foco no que é melhor para a comunidade.
+
+Exemplos de comportamento inaceitável:
+
+- Uso de linguagem ou imagens sexualizadas e atenção ou avanço sexual indesejado;
+- Trolagem, comentários insultuosos ou depreciativos e ataques pessoais ou políticos;
+- Assédio público ou privado;
+- Publicação de informações privadas de outras pessoas sem permissão explícita;
+- Qualquer outra conduta que possa ser razoavelmente considerada inadequada em um contexto profissional.
+
+## Responsabilidades de aplicação
+
+Os líderes da comunidade são responsáveis por esclarecer e fazer cumprir nossos padrões de comportamento aceitável e tomarão ações corretivas apropriadas e justas em resposta a qualquer comportamento que considerem inadequado, ameaçador, ofensivo ou danoso.
+
+Os líderes da comunidade têm o direito e a responsabilidade de remover, editar ou rejeitar comentários, commits, código, edições de wiki, issues e outras contribuições que não estejam alinhadas com este Código de Conduta, e comunicar os motivos por trás das decisões de moderação quando apropriado.
+
+## Alcance
+
+Este Código de Conduta se aplica a todos os espaços da comunidade e também se aplica quando uma pessoa representa oficialmente a comunidade em espaços públicos. Exemplos de representação incluem o uso de um endereço de e-mail oficial, postagens por meio de uma conta de mídia social oficial ou atuação como representante designado em um evento online ou offline.
+
+## Aplicação
+
+Instâncias de comportamento abusivo, assediador ou de outra forma inaceitável podem ser relatadas aos responsáveis pela manutenção da comunidade através de issues ou por contato direto com a equipe de manutenção. Todas as reclamações serão revisadas e investigadas prontamente e de maneira justa.
+
+Todos os líderes comunitários são obrigados a respeitar a privacidade e a segurança de quem reportar qualquer incidente.
+
+## Diretrizes de Aplicação
+
+Os líderes da comunidade seguirão estas diretrizes ao determinar as consequências de qualquer ação que considerarem violadora deste Código de Conduta:
+
+1. **Correção**
+   - *Impacto comunitário*: Uso de linguagem inadequada ou outro comportamento considerado não profissional ou indesejado na comunidade.
+   - *Consequência*: Aviso escrito privado dos líderes da comunidade, esclarecendo a natureza da violação e explicando por que o comportamento era inapropriado. Um pedido de desculpas público pode ser solicitado.
+2. **Aviso**
+   - *Impacto comunitário*: Uma violação através de um incidente único ou série de ações.
+   - *Consequência*: Aviso por escrito e consequências de longo prazo especificadas, incluindo suspensão do envolvimento na comunidade por um período.
+3. **Banimento Temporário**
+   - *Impacto comunitário*: Uma violação grave dos padrões da comunidade, incluindo comportamento inadequado prolongado.
+   - *Consequência*: Banimento temporário de qualquer forma de interação ou comunicação pública com a comunidade.
+4. **Banimento Permanente**
+   - *Impacto comunitário*: Demonstração de um padrão de violação da comunidade, incluindo assédio ou desacordo contínuo.
+   - *Consequência*: Banimento permanente de qualquer interação pública dentro da comunidade.
+
+## Atribuição
+
+Este Código de Conduta é adaptado do [Contributor Covenant][homepage], versão 2.1, disponível em <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+As diretrizes de aplicação foram inspiradas no [Código de Conduta da Mozilla](https://github.com/mozilla/diversity).
+
+Para obter respostas a perguntas comuns sobre este Código de Conduta, consulte as Perguntas Frequentes em <https://www.contributor-covenant.org/faq>. Traduções estão disponíveis em <https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contribuindo com CountG
+
+Obrigado por considerar uma contribuição para o projeto! Este documento descreve o fluxo de trabalho adotado, o padrão de mensagens de commit e como preparar o ambiente de desenvolvimento.
+
+## Fluxo de trabalho
+
+1. Faça um fork do repositório e clone o seu fork.
+2. Crie um branch descritivo para cada alteração (`git checkout -b minha-feature`).
+3. Realize alterações pequenas e bem testadas.
+4. Garanta que os testes e as ferramentas de lint passam.
+5. Abra um Pull Request para a branch principal descrevendo claramente as mudanças.
+
+## Padrão de commits
+
+Utilizamos o formato [Conventional Commits](https://www.conventionalcommits.org/):
+
+- `feat`: nova funcionalidade
+- `fix`: correção de bug
+- `docs`: alterações apenas na documentação
+- `refactor`, `test`, `chore`, etc.
+
+O formato básico é:
+
+```
+tipo(escopo opcional): descrição curta
+
+Corpo (opcional)
+```
+
+Exemplo:
+
+```
+feat: adiciona rota para upload de vídeo
+```
+
+## Ambiente de desenvolvimento
+
+1. Requer **Python 3.10+**.
+2. Crie e ative um ambiente virtual:
+   ```bash
+   python -m venv venv
+   source venv/bin/activate   # Linux/Mac
+   venv\Scripts\activate     # Windows
+   ```
+3. Instale as dependências principais:
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. Instale as dependências de desenvolvimento (lint e testes):
+   ```bash
+   pip install black flake8 pytest
+   ```
+5. Execute os testes e verificações de estilo antes de enviar o PR:
+   ```bash
+   flake8
+   pytest
+   ```
+
+## Dúvidas
+
+Em caso de dúvidas, abra uma issue explicando o problema ou entre em contato através das discussões do repositório.
+
+Obrigado por contribuir!


### PR DESCRIPTION
## Summary
- add CONTRIBUTING.md explaining workflow, commits and dev environment
- add Contributor Covenant code of conduct
- add issue and PR templates

## Testing
- `flake8` *(fails: F401 and many E501, etc.)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8b643e16483218f8e7629f45ab64c