### PR TITLE
Add multilingual MkDocs documentation and publish workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,20 @@
+name: docs
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install mkdocs mkdocs-material mkdocs-static-i18n
+      - name: Build and Deploy
+        run: mkdocs gh-deploy --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ curl http://localhost:8000/cancelar-processamento/video.mp4
 
 Para mais informações, consulte a [documentação completa](https://USER.github.io/CountG/).
 
+### Documentação
+Instale as dependências de documentação e rode localmente:
+
+```bash
+pip install mkdocs mkdocs-material mkdocs-static-i18n
+mkdocs serve
+```
+
+Para publicar no GitHub Pages:
+
+```bash
+mkdocs gh-deploy --force
+```
+
 ### Links Relevantes
 - [Documentação FastAPI](https://fastapi.tiangolo.com/)
 - [YOLOv8](https://docs.ultralytics.com/)
@@ -211,6 +225,20 @@ curl http://localhost:8000/cancelar-processamento/video.mp4
 ```
 
 Check the [full documentation](https://USER.github.io/CountG/) for more details.
+
+### Documentation
+Install the documentation dependencies and run locally:
+
+```bash
+pip install mkdocs mkdocs-material mkdocs-static-i18n
+mkdocs serve
+```
+
+To publish to GitHub Pages:
+
+```bash
+mkdocs gh-deploy --force
+```
 
 ### Useful Links
 - [FastAPI Documentation](https://fastapi.tiangolo.com/)

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -1,0 +1,87 @@
+# API Reference
+
+All endpoints return JSON.
+
+## `GET /`
+**Response**
+```json
+{
+  "status": "KYO DAY Backend is running!",
+  "database_url_loaded": true
+}
+```
+```bash
+curl http://localhost:8000/
+```
+
+## `POST /upload-video/`
+Upload a video file.
+
+**Request** (multipart)
+- `file`: video file
+
+**Response**
+```json
+{
+  "message": "Arquivo 'video.mp4' recebido com sucesso.",
+  "nome_arquivo": "<generated-name>.mp4"
+}
+```
+```bash
+curl -X POST -F "file=@my_video.mp4" http://localhost:8000/upload-video/
+```
+
+## `POST /predict-video/`
+Start processing a previously uploaded video.
+
+**Request**
+```json
+{
+  "nome_arquivo": "<generated-name>.mp4",
+  "orientation": "S",
+  "model_choice": "l",
+  "target_classes": ["cow"],
+  "line_position_ratio": 0.5
+}
+```
+
+**Response**
+```json
+{
+  "status": "iniciado",
+  "message": "Processamento para '<generated-name>.mp4' iniciado.",
+  "video_name": "<generated-name>.mp4"
+}
+```
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"nome_arquivo":"<generated-name>.mp4","orientation":"S"}' \
+  http://localhost:8000/predict-video/
+```
+
+## `GET /progresso/{video_name}`
+Check processing progress.
+
+**Response**
+```json
+{
+  "status": "em_processamento",
+  "progresso": 42
+}
+```
+```bash
+curl http://localhost:8000/progresso/<generated-name>.mp4
+```
+
+## `GET /cancelar-processamento/{video_name}`
+Cancel processing of a video.
+
+**Response**
+```json
+{
+  "message": "Solicitação de cancelamento para <generated-name>.mp4 enviada."
+}
+```
+```bash
+curl http://localhost:8000/cancelar-processamento/<generated-name>.mp4
+```

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,0 +1,3 @@
+# CountG Overview
+
+CountG is a FastAPI backend for counting and tracking objects in video using YOLOv8 models. This documentation covers environment setup and a full API reference. Use the language selector at the top right to switch between English and Portuguese.

--- a/docs/en/setup.md
+++ b/docs/en/setup.md
@@ -1,0 +1,22 @@
+# Environment Setup
+
+## Prerequisites
+- Python 3.10+
+- pip
+- Optional: virtualenv
+
+## Installation
+```bash
+git clone https://github.com/USER/CountG.git
+cd CountG
+python -m venv venv
+source venv/bin/activate  # Linux/Mac
+venv\Scripts\activate    # Windows
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+```
+
+## Running Locally
+```bash
+uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+```

--- a/docs/pt/api-reference.md
+++ b/docs/pt/api-reference.md
@@ -1,0 +1,87 @@
+# Referência da API
+
+Todos os endpoints retornam JSON.
+
+## `GET /`
+**Resposta**
+```json
+{
+  "status": "KYO DAY Backend is running!",
+  "database_url_loaded": true
+}
+```
+```bash
+curl http://localhost:8000/
+```
+
+## `POST /upload-video/`
+Envia um arquivo de vídeo.
+
+**Requisição** (multipart)
+- `file`: arquivo de vídeo
+
+**Resposta**
+```json
+{
+  "message": "Arquivo 'video.mp4' recebido com sucesso.",
+  "nome_arquivo": "<nome-gerado>.mp4"
+}
+```
+```bash
+curl -X POST -F "file=@meu_video.mp4" http://localhost:8000/upload-video/
+```
+
+## `POST /predict-video/`
+Inicia o processamento de um vídeo previamente enviado.
+
+**Requisição**
+```json
+{
+  "nome_arquivo": "<nome-gerado>.mp4",
+  "orientation": "S",
+  "model_choice": "l",
+  "target_classes": ["cow"],
+  "line_position_ratio": 0.5
+}
+```
+
+**Resposta**
+```json
+{
+  "status": "iniciado",
+  "message": "Processamento para '<nome-gerado>.mp4' iniciado.",
+  "video_name": "<nome-gerado>.mp4"
+}
+```
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"nome_arquivo":"<nome-gerado>.mp4","orientation":"S"}' \
+  http://localhost:8000/predict-video/
+```
+
+## `GET /progresso/{video_name}`
+Consulta o progresso do processamento.
+
+**Resposta**
+```json
+{
+  "status": "em_processamento",
+  "progresso": 42
+}
+```
+```bash
+curl http://localhost:8000/progresso/<nome-gerado>.mp4
+```
+
+## `GET /cancelar-processamento/{video_name}`
+Cancela o processamento de um vídeo.
+
+**Resposta**
+```json
+{
+  "message": "Solicitação de cancelamento para <nome-gerado>.mp4 enviada."
+}
+```
+```bash
+curl http://localhost:8000/cancelar-processamento/<nome-gerado>.mp4
+```

--- a/docs/pt/index.md
+++ b/docs/pt/index.md
@@ -1,0 +1,3 @@
+# Visão Geral do CountG
+
+CountG é um backend em FastAPI para contagem e rastreamento de objetos em vídeo utilizando modelos YOLOv8. Esta documentação aborda a configuração do ambiente e uma referência completa da API. Use o seletor de idioma no canto superior direito para alternar entre Português e Inglês.

--- a/docs/pt/setup.md
+++ b/docs/pt/setup.md
@@ -1,0 +1,22 @@
+# Configuração do Ambiente
+
+## Pré-requisitos
+- Python 3.10+
+- pip
+- Opcional: virtualenv
+
+## Instalação
+```bash
+git clone https://github.com/USER/CountG.git
+cd CountG
+python -m venv venv
+source venv/bin/activate  # Linux/Mac
+venv\Scripts\activate    # Windows
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+```
+
+## Executando Localmente
+```bash
+uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,29 @@
+# To preview the documentation locally, run:
+#   mkdocs serve
+# To deploy to GitHub Pages, run:
+#   mkdocs gh-deploy --force
+
+site_name: CountG
+docs_dir: docs
+
+nav:
+  - Home: en/index.md
+  - Environment Setup: en/setup.md
+  - API Reference: en/api-reference.md
+
+plugins:
+  - search
+  - mkdocs-static-i18n:
+      default_language: en
+      languages:
+        en: English
+        pt: Português
+      docs_structure: folder
+      nav_translations:
+        pt:
+          Home: Início
+          Environment Setup: Configuração do Ambiente
+          API Reference: Referência da API
+
+theme:
+  name: material


### PR DESCRIPTION
## Summary
- add English and Portuguese docs for overview, setup and API reference
- configure MkDocs with `mkdocs-static-i18n` and Material theme
- build and deploy documentation to GitHub Pages via workflow

## Testing
- `pre-commit run --files mkdocs.yml README.md .github/workflows/docs.yml docs/en/index.md docs/en/setup.md docs/en/api-reference.md docs/pt/index.md docs/pt/setup.md docs/pt/api-reference.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb3fb41d3c8321ab6c8c9257b20ef1