### PR TITLE
docs: add bilingual docstrings

### DIFF
--- a/utils/contagem_video.py
+++ b/utils/contagem_video.py
@@ -33,7 +33,36 @@ def get_line_and_direction_config(
 ) -> Tuple[
     Optional[str], Optional[str], Optional[Tuple], Optional[int], Optional[Tuple]
 ]:
-    """Determina tipo de linha, posição e direção com base na orientação."""
+    """Determina tipo de linha, posição e direção com base na orientação.
+
+    Determine the line type, its position and the movement direction from an
+    orientation code.
+
+    Parâmetros / Parameters:
+        orientation_code (str): Código da orientação (ex.: ``"N"`` para norte).
+            Orientation code (e.g. ``"N"`` for north).
+        width (int): Largura do frame do vídeo.
+            Video frame width.
+        height (int): Altura do frame do vídeo.
+            Video frame height.
+        line_ratio (float, opcional): Posição relativa da linha dentro do
+            frame, variando de ``0`` a ``1``. Relative position of the line in
+            the frame, ranging from ``0`` to ``1``.
+
+    Retorno / Returns:
+        tuple: ``(line_type, direction, line_points, line_pos_value,
+        arrow_points)`` contendo o tipo e a orientação da linha.
+        Tuple describing line type and orientation as
+        ``(line_type, direction, line_points, line_pos_value, arrow_points)``.
+
+    Efeitos colaterais / Side Effects:
+        Emite mensagens de log quando a orientação é desconhecida.
+        Logs a warning when the orientation is unknown.
+
+    Exceções / Exceptions:
+        Nenhuma é lançada explicitamente.
+        None are explicitly raised.
+    """
     (
         line_type,
         effective_counting_direction,
@@ -135,6 +164,32 @@ def is_crossing_diagonal_line(
     line_p2: Tuple[int, int],
     direction: str,
 ) -> bool:
+    """Verifica se um objeto cruzou uma linha diagonal.
+
+    Check whether an object crossed a diagonal line.
+
+    Parâmetros / Parameters:
+        p_prev_x, p_prev_y (int): Coordenadas anteriores do objeto.
+            Previous object coordinates.
+        p_curr_x, p_curr_y (int): Coordenadas atuais do objeto.
+            Current object coordinates.
+        line_p1, line_p2 (Tuple[int, int]): Pontos que definem a linha.
+            Points that define the line.
+        direction (str): Direção esperada do cruzamento.
+            Expected crossing direction.
+
+    Retorno / Returns:
+        bool: ``True`` se o objeto cruzou na direção especificada, ``False`` caso contrário.
+        ``True`` if the object crossed in the expected direction, ``False`` otherwise.
+
+    Efeitos colaterais / Side Effects:
+        Nenhum.
+        None.
+
+    Exceções / Exceptions:
+        Nenhuma é lançada explicitamente.
+        None are explicitly raised.
+    """
     (x1_line, y1_line), (x2_line, y2_line) = line_p1, line_p2
     val_prev = (float(p_prev_y - y1_line) * (x2_line - x1_line)) - (
         float(p_prev_x - x1_line) * (y2_line - y1_line)
@@ -169,6 +224,52 @@ def contar_gado_em_video(
     status_check_interval: int = 30,
     cancel_callback: Optional[Callable[[], bool]] = None,
 ) -> Optional[Dict[str, Any]]:
+    """Realiza a contagem de gado em um arquivo de vídeo.
+
+    Count cattle in a video file.
+
+    Parâmetros / Parameters:
+        video_path (str): Caminho local para o vídeo.
+            Local path to the video file.
+        video_name (str): Nome do vídeo usado para logs e SFTP.
+            Video name used for logs and SFTP operations.
+        progresso_manager (Any): Instância que gerencia o progresso de
+            processamento. Instance that manages processing progress.
+        model_choice (str, opcional): Variante do modelo YOLO a ser usada
+            (``"n"``, ``"m"``, ``"l"`` ou ``"p"``). YOLO model variant to use.
+        frame_skip (int, opcional): Número de frames a pular entre análises.
+            Number of frames skipped between analyses.
+        orientation (str, opcional): Código da orientação da linha de
+            contagem. Line orientation code.
+        target_classes (List[str], opcional): Classes de interesse para
+            detecção. Target classes for detection.
+        line_position_ratio (float, opcional): Posição relativa da linha de
+            contagem. Relative position of the counting line.
+        status_check_interval (int, opcional): Intervalo em segundos para
+            verificar cancelamentos. Interval in seconds to check for
+            cancellation requests.
+        cancel_callback (Callable, opcional): Função que retorna ``True``
+            quando o processamento deve ser cancelado. Callback returning
+            ``True`` when the process should be cancelled.
+
+    Retorno / Returns:
+        dict | None: Dicionário com estatísticas da contagem ou ``None`` em
+        caso de erro ou cancelamento.
+        Dictionary with counting statistics or ``None`` if an error or
+        cancellation occurs.
+
+    Efeitos colaterais / Side Effects:
+        Pode enviar e deletar arquivos via SFTP, atualizar o progresso no
+        banco de dados e gerar vídeos anotados.
+        May upload/delete files over SFTP, update database progress and
+        generate annotated videos.
+
+    Exceções / Exceptions:
+        Erros são capturados internamente; em caso de falha a função retorna
+        ``None`` e registra o erro.
+        Exceptions are handled internally; on failure ``None`` is returned and
+        the error is logged.
+    """
 
     USE_SFTP = os.getenv("USE_SFTP", "false").lower() == "true"
     CREATE_ANNOTATED_VIDEO = (

--- a/utils/gerenciador_progresso.py
+++ b/utils/gerenciador_progresso.py
@@ -29,7 +29,26 @@ except Exception as e:
 
 
 def create_progress_table_if_not_exists():
-    """Garante que a tabela de progresso exista no banco de dados."""
+    """Garante que a tabela de progresso exista no banco de dados.
+
+    Ensure the progress table exists in the database.
+
+    Parâmetros / Parameters:
+        Nenhum / None
+
+    Retorno / Returns:
+        None: A função não retorna valores.
+        The function returns ``None``.
+
+    Efeitos colaterais / Side Effects:
+        Cria a tabela ``video_progress`` caso não exista e registra mensagens
+        no log.
+        Creates the ``video_progress`` table if missing and logs messages.
+
+    Exceções / Exceptions:
+        Erros de conexão ou SQL são capturados e logados; nenhum é propagado.
+        Connection or SQL errors are caught and logged; none are raised.
+    """
     if not pool:
         logger.warning(
             "[DB AVISO] Pool de conexões não disponível. Tabela não pôde ser verificada/criada."
@@ -71,12 +90,40 @@ create_progress_table_if_not_exists()
 
 
 class ProgressoManager:
-    """Gerencia o progresso do processamento de vídeo usando um banco de dados PostgreSQL."""
+    """Gerencia o progresso do processamento de vídeo usando PostgreSQL.
+
+    Manage video processing progress using a PostgreSQL database.
+
+    Esta classe centraliza operações de consulta e atualização na tabela
+    ``video_progress``.
+    This class centralizes querying and updating the ``video_progress`` table.
+    """
 
     def _execute_query(
         self, query: str, params: tuple = (), fetch: Optional[str] = None
     ):
-        """Função auxiliar para executar queries no banco de dados usando o pool."""
+        """Função auxiliar para executar queries no banco de dados usando o pool.
+
+        Helper function to execute queries using the connection pool.
+
+        Parâmetros / Parameters:
+            query (str): Comando SQL a ser executado. SQL statement to run.
+            params (tuple): Parâmetros para o SQL. Parameters for the SQL.
+            fetch (str, opcional): Se ``"one"`` ou ``"all"`` define o tipo de
+                retorno. If ``"one"`` or ``"all"`` defines the fetch mode.
+
+        Retorno / Returns:
+            Resultado da query ou ``None`` se não houver retorno.
+            Query result or ``None`` when no data is fetched.
+
+        Efeitos colaterais / Side Effects:
+            Executa commits e rollbacks no banco de dados e registra logs.
+            Performs commits/rollbacks on the database and logs messages.
+
+        Exceções / Exceptions:
+            Erros são capturados, registrados e não propagados.
+            Errors are caught, logged, and not propagated.
+        """
         if not pool:
             logger.error(
                 "[DB ERRO] Tentativa de executar query sem um pool de conexões válido."
@@ -105,7 +152,27 @@ class ProgressoManager:
                 pool.putconn(conn)
 
     def iniciar(self, video_name: str):
-        """Inicia ou reseta o progresso para um vídeo no banco de dados."""
+        """Inicia ou reseta o progresso para um vídeo no banco de dados.
+
+        Start or reset progress for a video in the database.
+
+        Parâmetros / Parameters:
+            video_name (str): Identificador do vídeo.
+                Video identifier.
+
+        Retorno / Returns:
+            None: Não retorna valores.
+            The method returns ``None``.
+
+        Efeitos colaterais / Side Effects:
+            Insere ou atualiza registros na tabela ``video_progress`` e gera
+            mensagens de log.
+            Inserts or updates records in ``video_progress`` and logs messages.
+
+        Exceções / Exceptions:
+            Erros de banco são capturados pelo ``_execute_query``.
+            Database errors are handled by ``_execute_query``.
+        """
         query = """
             INSERT INTO video_progress (video_name, tempo_inicio, tempo_restante, finalizado, cancelado, erro, resultado, frame_atual, total_frames_estimado, last_updated)
             VALUES (%s, %s, %s, %s, %s, NULL, NULL, 0, 1, NOW())
@@ -120,7 +187,27 @@ class ProgressoManager:
         logger.info(f"[DB Progresso] Progresso iniciado/resetado para: {video_name}")
 
     def is_processing(self, video_name: str) -> bool:
-        """Verifica no banco se um vídeo está atualmente em processamento."""
+        """Verifica no banco se um vídeo está atualmente em processamento.
+
+        Check in the database whether a video is being processed.
+
+        Parâmetros / Parameters:
+            video_name (str): Nome do vídeo.
+                Video name.
+
+        Retorno / Returns:
+            bool: ``True`` se o processamento está ativo, ``False`` caso
+            contrário.
+            ``True`` if processing is active, ``False`` otherwise.
+
+        Efeitos colaterais / Side Effects:
+            Executa uma consulta no banco de dados.
+            Executes a database query.
+
+        Exceções / Exceptions:
+            Erros de banco são capturados pelo ``_execute_query``.
+            Database errors are handled by ``_execute_query``.
+        """
         status = self.status(video_name)
         return bool(status and not status.get("erro") and not status.get("finalizado"))
 
@@ -131,7 +218,30 @@ class ProgressoManager:
         total_estimado: int,
         no_processing: bool = False,
     ) -> bool:
-        """Atualiza o progresso do processamento de frames no banco de dados."""
+        """Atualiza o progresso do processamento de frames no banco de dados.
+
+        Update the frame-processing progress in the database.
+
+        Parâmetros / Parameters:
+            video_name (str): Nome do vídeo. Video name.
+            frame_atual (int): Frame atual processado. Current processed frame.
+            total_estimado (int): Total de frames estimado. Estimated total
+                frames.
+            no_processing (bool, opcional): ``True`` evita cálculo de tempo
+                restante. ``True`` skips remaining time calculation.
+
+        Retorno / Returns:
+            bool: ``True`` se a atualização ocorreu, ``False`` caso contrário.
+            ``True`` if the update took place, ``False`` otherwise.
+
+        Efeitos colaterais / Side Effects:
+            Atualiza registros no banco de dados e calcula tempo restante.
+            Updates database records and computes remaining time.
+
+        Exceções / Exceptions:
+            Erros de banco são capturados pelo ``_execute_query``.
+            Database errors are handled by ``_execute_query``.
+        """
         status = self.status(video_name)
         if not status or status.get("cancelado") or status.get("finalizado"):
             return False
@@ -157,7 +267,26 @@ class ProgressoManager:
 
     # --- MÉTODO NOVO QUE ESTAVA FALTANDO ---
     def update_status_message(self, video_name: str, message: str):
-        """Atualiza a mensagem de status (usando o campo tempo_restante) para tarefas como SFTP."""
+        """Atualiza a mensagem de status para tarefas como SFTP.
+
+        Update the status message (stored in ``tempo_restante``) for tasks like
+        SFTP transfers.
+
+        Parâmetros / Parameters:
+            video_name (str): Nome do vídeo. Video name.
+            message (str): Mensagem a exibir. Message to display.
+
+        Retorno / Returns:
+            None
+
+        Efeitos colaterais / Side Effects:
+            Escreve no banco de dados e registra logs. Writes to the database
+            and logs messages.
+
+        Exceções / Exceptions:
+            Erros de banco são capturados pelo ``_execute_query``.
+            Database errors are handled by ``_execute_query``.
+        """
         if self.status(video_name).get("finalizado"):
             return
         query = "UPDATE video_progress SET tempo_restante = %s, last_updated = NOW() WHERE video_name = %s;"
@@ -166,7 +295,26 @@ class ProgressoManager:
         # Removido o print daqui para não poluir o log a cada % de progresso do SFTP
 
     def finalizar(self, video_name: str, resultado: dict):
-        """Marca o processamento como finalizado com sucesso no banco de dados."""
+        """Marca o processamento como finalizado com sucesso no banco de dados.
+
+        Mark processing as successfully finished in the database.
+
+        Parâmetros / Parameters:
+            video_name (str): Nome do vídeo. Video name.
+            resultado (dict): Resultado final da contagem. Final counting
+                result.
+
+        Retorno / Returns:
+            None
+
+        Efeitos colaterais / Side Effects:
+            Atualiza registros no banco e gera logs. Updates database records
+            and logs messages.
+
+        Exceções / Exceptions:
+            Erros de banco são capturados pelo ``_execute_query``.
+            Database errors are handled by ``_execute_query``.
+        """
         status = self.status(video_name)
         frame_final = (
             status.get("total_frames_estimado", status.get("frame_atual", 0))
@@ -183,7 +331,25 @@ class ProgressoManager:
         logger.info(f"[DB Progresso] Finalizado com sucesso para: {video_name}")
 
     def erro(self, video_name: str, mensagem: str):
-        """Marca o processamento como finalizado com erro no banco de dados."""
+        """Marca o processamento como finalizado com erro no banco de dados.
+
+        Mark processing as finished with an error in the database.
+
+        Parâmetros / Parameters:
+            video_name (str): Nome do vídeo. Video name.
+            mensagem (str): Descrição do erro. Error description.
+
+        Retorno / Returns:
+            None
+
+        Efeitos colaterais / Side Effects:
+            Atualiza o banco de dados e registra logs de erro.
+            Updates the database and logs the error.
+
+        Exceções / Exceptions:
+            Erros de banco são capturados pelo ``_execute_query``.
+            Database errors are handled by ``_execute_query``.
+        """
         query = "UPDATE video_progress SET finalizado = TRUE, erro = %s, tempo_restante = 'Erro', last_updated = NOW() WHERE video_name = %s;"
         if not self.status(video_name).get("erro"):
             self.iniciar(video_name)  # Garante que a linha exista antes de atualizar
@@ -192,7 +358,25 @@ class ProgressoManager:
         logger.error(f"[DB Progresso] Erro registrado para: {video_name}")
 
     def status(self, video_name: str) -> Dict[str, Any]:
-        """Retorna o status atual de um vídeo do banco de dados."""
+        """Retorna o status atual de um vídeo do banco de dados.
+
+        Return the current status of a video from the database.
+
+        Parâmetros / Parameters:
+            video_name (str): Nome do vídeo. Video name.
+
+        Retorno / Returns:
+            dict: Dicionário com informações de progresso.
+            Dictionary containing progress information.
+
+        Efeitos colaterais / Side Effects:
+            Executa consulta no banco de dados.
+            Performs a database query.
+
+        Exceções / Exceptions:
+            Erros de banco são capturados pelo ``_execute_query``.
+            Database errors are handled by ``_execute_query``.
+        """
         query = "SELECT video_name, frame_atual, total_frames_estimado, tempo_inicio, tempo_restante, finalizado, resultado, erro, cancelado FROM video_progress WHERE video_name = %s;"
         result = self._execute_query(query, (video_name,), fetch="one")
         if result:
@@ -215,7 +399,25 @@ class ProgressoManager:
         }
 
     def cancelar(self, video_name: str) -> bool:
-        """Sinaliza no banco de dados que o processamento deve ser cancelado."""
+        """Sinaliza no banco de dados que o processamento deve ser cancelado.
+
+        Signal in the database that processing should be cancelled.
+
+        Parâmetros / Parameters:
+            video_name (str): Nome do vídeo. Video name.
+
+        Retorno / Returns:
+            bool: ``True`` se o cancelamento foi registrado.
+            ``True`` if the cancellation was recorded.
+
+        Efeitos colaterais / Side Effects:
+            Atualiza registros no banco e gera logs.
+            Updates database records and logs messages.
+
+        Exceções / Exceptions:
+            Erros de banco são capturados pelo ``_execute_query``.
+            Database errors are handled by ``_execute_query``.
+        """
         status = self.status(video_name)
         if status and not status.get("finalizado"):
             query = "UPDATE video_progress SET cancelado = TRUE, finalizado = TRUE, erro = 'Cancelado pelo usuário.', tempo_restante = 'Cancelado', last_updated = NOW() WHERE video_name = %s;"

--- a/utils/sftp_handler.py
+++ b/utils/sftp_handler.py
@@ -16,7 +16,25 @@ HG_PORT = int(os.getenv("HG_PORT", 22))
 
 
 def sftp_connect() -> Optional[Tuple[paramiko.SFTPClient, paramiko.Transport]]:
-    """Cria e retorna um cliente SFTP conectado."""
+    """Cria e retorna um cliente SFTP conectado.
+
+    Create and return a connected SFTP client.
+
+    Parâmetros / Parameters:
+        Nenhum / None (usa variáveis de ambiente).
+
+    Retorno / Returns:
+        tuple | None: Par ``(sftp, transport)`` ou ``(None, None)`` em caso de
+        falha. Pair ``(sftp, transport)`` or ``(None, None)`` on failure.
+
+    Efeitos colaterais / Side Effects:
+        Estabelece conexão com o servidor e registra logs.
+        Establishes a server connection and logs messages.
+
+    Exceções / Exceptions:
+        Qualquer exceção é capturada e registrada; ``None`` é retornado.
+        Exceptions are caught and logged; ``None`` is returned.
+    """
     if not all([HG_HOST, HG_USER, HG_PASS]):
         logger.error(
             "[SFTP ERRO] Variáveis de ambiente (HG_HOST, HG_USER, HG_PASS) não estão configuradas."
@@ -34,9 +52,24 @@ def sftp_connect() -> Optional[Tuple[paramiko.SFTPClient, paramiko.Transport]]:
 
 
 def _ensure_remote_dir_exists(sftp: paramiko.SFTPClient, remote_path: str):
-    """
-    Função auxiliar interna para garantir que um diretório remoto exista,
-    criando-o recursivamente se necessário.
+    """Garante que um diretório remoto exista, criando-o recursivamente.
+
+    Ensure that a remote directory exists, creating it recursively if needed.
+
+    Parâmetros / Parameters:
+        sftp (paramiko.SFTPClient): Cliente SFTP ativo. Active SFTP client.
+        remote_path (str): Caminho remoto completo. Full remote path.
+
+    Retorno / Returns:
+        None
+
+    Efeitos colaterais / Side Effects:
+        Cria diretórios no servidor remoto e registra logs.
+        Creates directories on the remote server and logs messages.
+
+    Exceções / Exceptions:
+        Exceções do SFTP não são tratadas aqui.
+        SFTP exceptions are not handled here.
     """
     remote_dir = os.path.dirname(remote_path.replace("\\", "/"))
     if not remote_dir or remote_dir == ".":
@@ -68,7 +101,31 @@ def upload_file_sftp(
     remote_path: str,
     progress_callback: Optional[Callable[[int, int], None]] = None,
 ) -> bool:
-    """Faz upload de um arquivo local para um caminho remoto via SFTP, com callback de progresso."""
+    """Faz upload de um arquivo local para um caminho remoto via SFTP.
+
+    Upload a local file to a remote path via SFTP.
+
+    Parâmetros / Parameters:
+        local_path (str): Caminho do arquivo local. Local file path.
+        remote_path (str): Caminho remoto de destino. Remote destination path.
+        progress_callback (Callable, opcional): Função de progresso
+            ``(transferred, total)``. Progress callback ``(transferred,
+            total)``.
+
+    Retorno / Returns:
+        bool: ``True`` se o upload foi bem-sucedido.
+        ``True`` if the upload succeeded.
+
+    Efeitos colaterais / Side Effects:
+        Cria diretórios remotos conforme necessário, transfere o arquivo e
+        registra logs.
+        Creates remote directories as needed, transfers the file and logs
+        messages.
+
+    Exceções / Exceptions:
+        Erros de SFTP são capturados e resultam em ``False``.
+        SFTP errors are caught and result in ``False``.
+    """
     sftp, transport = sftp_connect()
     if not sftp:
         return False
@@ -96,7 +153,29 @@ def download_file_sftp(
     local_path: str,
     progress_callback: Optional[Callable[[int, int], None]] = None,
 ) -> bool:
-    """Baixa um arquivo de um caminho remoto para um local via SFTP, com callback de progresso."""
+    """Baixa um arquivo de um caminho remoto para um local via SFTP.
+
+    Download a file from a remote path to a local path via SFTP.
+
+    Parâmetros / Parameters:
+        remote_path (str): Caminho remoto de origem. Remote source path.
+        local_path (str): Caminho local de destino. Local destination path.
+        progress_callback (Callable, opcional): Função de progresso
+            ``(transferred, total)``. Progress callback ``(transferred,
+            total)``.
+
+    Retorno / Returns:
+        bool: ``True`` se o download foi bem-sucedido.
+        ``True`` if the download succeeded.
+
+    Efeitos colaterais / Side Effects:
+        Transfere arquivos para o sistema local e registra logs.
+        Transfers files to the local system and logs messages.
+
+    Exceções / Exceptions:
+        Erros de SFTP são capturados e resultam em ``False``.
+        SFTP errors are caught and result in ``False``.
+    """
     sftp, transport = sftp_connect()
     if not sftp:
         return False
@@ -118,7 +197,25 @@ def download_file_sftp(
 
 
 def delete_file_sftp(remote_path: str) -> bool:
-    """Deleta um arquivo em um caminho remoto via SFTP."""
+    """Deleta um arquivo em um caminho remoto via SFTP.
+
+    Delete a file at a remote path via SFTP.
+
+    Parâmetros / Parameters:
+        remote_path (str): Caminho do arquivo remoto. Remote file path.
+
+    Retorno / Returns:
+        bool: ``True`` se o arquivo foi removido ou já inexistente.
+        ``True`` if the file was removed or already absent.
+
+    Efeitos colaterais / Side Effects:
+        Remove arquivos no servidor remoto e registra logs.
+        Removes files on the remote server and logs messages.
+
+    Exceções / Exceptions:
+        Erros de SFTP são capturados e retornam ``False``.
+        SFTP errors are caught and result in ``False``.
+    """
     sftp, transport = sftp_connect()
     if not sftp:
         return False


### PR DESCRIPTION
## Summary
- document line configuration helper with bilingual parameter and return details
- clarify cattle counting workflow via bilingual docstring
- expand progress manager and SFTP utilities with Portuguese/English docstrings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb3d55217883219a0faa84e2efdfb4