### PR TITLE
docs: annotate environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,19 @@
-# Example environment configuration
+# Example environment configuration / Exemplo de configuração de ambiente
 
-# Roboflow API key (used for dataset downloads)
-ROBOFLOW_API_KEY=
+ROBOFLOW_API_KEY= # Chave da API do Roboflow para baixar datasets / Roboflow API key for dataset downloads (sem padrão/no default; obrigatório/required; não compartilhar/do not share)
 
-# PostgreSQL database URL
-DATABASE_URL=
+DATABASE_URL= # URL do banco PostgreSQL / PostgreSQL database URL (sem padrão/no default; obrigatório/required; não compartilhar/do not share)
 
-# HostGator SFTP credentials
-HG_HOST=
-HG_USER=
-HG_PASS=
-HG_PORT=22
-HG_DOMAIN=
+# HostGator SFTP credentials / Credenciais SFTP do HostGator
+HG_HOST= # Servidor SFTP do HostGator / HostGator SFTP server (sem padrão/no default; obrigatório se USE_SFTP=true/required when USE_SFTP=true; pode ser público/can be public)
+HG_USER= # Usuário SFTP do HostGator / HostGator SFTP username (sem padrão/no default; obrigatório se USE_SFTP=true/required when USE_SFTP=true; não compartilhar/do not share)
+HG_PASS= # Senha SFTP do HostGator / HostGator SFTP password (sem padrão/no default; obrigatório se USE_SFTP=true/required when USE_SFTP=true; não compartilhar/do not share)
+HG_PORT=22 # Porta SFTP do HostGator / HostGator SFTP port (padrão: 22/default: 22; opcional/optional; pode ser público/can be public)
+HG_DOMAIN= # Domínio no HostGator / HostGator domain (sem padrão/no default; opcional/optional; pode ser público/can be public)
 
-# Development flags
-USE_SFTP=false
-CREATE_ANNOTATED_VIDEO=true
+# Development flags / Flags de desenvolvimento
+USE_SFTP=false # Ativa envio via SFTP / Enables SFTP upload (padrão: false/default: false; opcional/optional; informação pública/public info)
+CREATE_ANNOTATED_VIDEO=true # Gera vídeo anotado / Creates annotated video (padrão: true/default: true; opcional/optional; informação pública/public info)
 
-# Number of threads for computation
-OMP_NUM_THREADS=12
+# Number of threads for computation / Número de threads para computação
+OMP_NUM_THREADS=12 # Número de threads para processamento / Number of processing threads (padrão: 12/default: 12; opcional/optional; informação pública/public info)


### PR DESCRIPTION
## Summary
- add bilingual inline explanations for environment variables in `.env.example`

## Testing
- `pre-commit run --files .env.example`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb4b928bbc8321a46237195181279b