### PR TITLE
docs: add bilingual docstrings to tests

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,3 +1,14 @@
+"""Testes das rotas de upload de vídeo.
+
+O objetivo é confirmar que a API recusa arquivos com extensões inválidas e aceita
+vídeos com extensões permitidas.
+
+Tests for the video upload routes.
+
+The goal is to confirm the API rejects files with invalid extensions and
+accepts videos with permitted extensions.
+"""
+
 import os
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -9,6 +20,8 @@ app.include_router(router)
 
 
 def test_upload_video_endpoint_rejects_invalid_extension():
+    """Return a 400 error when a file with an unsupported extension is uploaded."""
+
     client = TestClient(app)
     response = client.post(
         "/upload-video/",
@@ -19,6 +32,8 @@ def test_upload_video_endpoint_rejects_invalid_extension():
 
 
 def test_upload_video_endpoint_accepts_valid_extension(tmp_path):
+    """Accept a valid video file and store it in the uploads directory."""
+
     # Ensure uploads go to a temporary directory
     data_dir = tmp_path / "data"
     uploads_dir = data_dir / "uploads"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,14 @@
+"""Testes para utilidades de contagem de vídeo.
+
+O módulo valida a configuração de linhas e direções e a detecção de
+cruzamentos de linhas diagonais.
+
+Tests for video counting utilities.
+
+The module validates line and direction configuration and detection of
+diagonal line crossings.
+"""
+
 from utils.contagem_video import (
     get_line_and_direction_config,
     LINE_VERTICAL,
@@ -8,6 +19,8 @@ from utils.contagem_video import (
 
 
 def test_get_line_and_direction_config_east():
+    """Return a centered vertical line moving from left to right for east."""
+
     line_type, direction, line_points, pos, _ = get_line_and_direction_config(
         'E', width=100, height=50
     )
@@ -18,6 +31,8 @@ def test_get_line_and_direction_config_east():
 
 
 def test_is_crossing_diagonal_line():
+    """Detect crossing of a top-left to bottom-right diagonal line."""
+
     p_prev = (10, 20)
     p_curr = (30, 25)
     line_p1 = (0, 0)


### PR DESCRIPTION
## Summary
- document video route tests in Portuguese and English
- document video utility tests in Portuguese and English
- clarify expected behavior for each test function

## Testing
- `pytest tests/test_routes.py tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb707656248321bec97cbb79722c47