### PR TITLE
chore: remove unused SFTP upload import

### DIFF
--- a/routes/video_routes.py
+++ b/routes/video_routes.py
@@ -12,7 +12,6 @@ from fastapi.responses import JSONResponse
 from schemas import VideoRequest
 from utils.contagem_video import contar_gado_em_video
 from utils.gerenciador_progresso import ProgressoManager
-from utils.sftp_handler import upload_file_sftp
 
 router = APIRouter()
 DATA_DIR = os.getenv("RENDER_DATA_DIR", "data")


### PR DESCRIPTION
## Summary
- remove unused `upload_file_sftp` import from video routes

## Testing
- `pre-commit run --files routes/video_routes.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc3855bb088321932ed52936d5e74b