### PR TITLE
Log saved file size in upload endpoint

### DIFF
--- a/routes/video_routes.py
+++ b/routes/video_routes.py
@@ -85,6 +85,9 @@ async def upload_video_endpoint(file: UploadFile = File(...)):
     try:
         with open(temp_local_path, "wb") as buffer:
             shutil.copyfileobj(file.file, buffer)
+        logger.debug(
+            f"[UPLOAD] Saved size: {os.path.getsize(temp_local_path)} bytes"
+        )
         logger.info(f"[UPLOAD] Vídeo salvo temporariamente em: {temp_local_path}")
     except Exception as e:
         logger.error(f"[UPLOAD ERRO] Falha ao salvar o arquivo temporariamente: {e}")


### PR DESCRIPTION
## Summary
- log uploaded video file size after saving

## Testing
- `pytest`
- manual upload via TestClient to verify logged file size

------
https://chatgpt.com/codex/tasks/task_e_68bda9462f148321abd0a90a056d8e8d