### PR TITLE
Defina valor padrão para line_position_ratio

### DIFF
--- a/utils/contagem_video.py
+++ b/utils/contagem_video.py
@@ -351,6 +351,9 @@ def contar_gado_em_video(
         cap.release()
         return None
 
+    if line_position_ratio is None:
+        line_position_ratio = 0.5
+
     line_type, effective_counting_dir, line_points, line_coord_val, arrow_points = (
         get_line_and_direction_config(orientation, width, height, line_position_ratio)
     )


### PR DESCRIPTION
## Summary
- Assegure valor padrão de 0.5 quando `line_position_ratio` não for informado na contagem de gado em vídeo.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdb8cd71bc832183e03ec75007e53f