### PR TITLE
docs: add OpenAPI schema to nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
   - Home: en/index.md
   - Environment Setup: en/setup.md
   - API Reference: en/api-reference.md
+  - OpenAPI Schema: openapi.json
 
 plugins:
   - search
@@ -24,6 +25,7 @@ plugins:
           Home: Início
           Environment Setup: Configuração do Ambiente
           API Reference: Referência da API
+          OpenAPI Schema: Esquema OpenAPI
 
 theme:
   name: material


### PR DESCRIPTION
## Summary
- link OpenAPI schema in mkdocs navigation
- localize OpenAPI schema entry in Portuguese

## Testing
- `mkdocs serve -f mkdocs_tmp.yml` (with curl requests to verify links)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdbc3fa59c8321980604a91f47eb30