### PR TITLE
Persist annotated video when CREATE_ANNOTATED_VIDEO is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ CREATE_ANNOTATED_VIDEO=true
 OMP_NUM_THREADS=12
 ```
 
+Quando `CREATE_ANNOTATED_VIDEO` está ativado, o vídeo anotado (com linha e contador) é salvo. Se `USE_SFTP=false`, o arquivo ficará disponível localmente em `videos_processados/`.
+
 ### Uso da API
 Exemplos de requisições:
 
@@ -198,6 +200,8 @@ USE_SFTP=false
 CREATE_ANNOTATED_VIDEO=true
 OMP_NUM_THREADS=12
 ```
+
+When `CREATE_ANNOTATED_VIDEO` is enabled, the service saves the annotated video (with line and counter). If `USE_SFTP=false`, the file is kept locally in `videos_processados/`.
 
 ### API Usage
 Request examples:

--- a/utils/contagem_video.py
+++ b/utils/contagem_video.py
@@ -377,7 +377,9 @@ def contar_gado_em_video(
     local_output_path = ""
     processed_fn = ""
     if CREATE_ANNOTATED_VIDEO:
-        output_dir_local = "videos_processados_temp"
+        output_dir_local = (
+            "videos_processados_temp" if USE_SFTP else "videos_processados"
+        )
         os.makedirs(output_dir_local, exist_ok=True)
         base_name, vid_ext = os.path.splitext(video_name)
         processed_fn = f"processed_{base_name}{vid_ext}"
@@ -604,15 +606,9 @@ def contar_gado_em_video(
                 if progresso_manager:
                     progresso_manager.erro(video_name, public_url)
         else:
-            # Provide the local file path to the caller before cleanup in case the frontend
-            # needs to access the processed video. The file is removed immediately after
-            # logging.
+            # Store the processed video locally for later access.
             public_url = local_output_path
-            logger.info(
-                f"[INFO] Processed video saved at {local_output_path} and will not be uploaded."
-            )
-            if os.path.exists(local_output_path):
-                os.remove(local_output_path)
+            logger.info(f"[INFO] Processed video saved at {local_output_path}.")
 
     if USE_SFTP:
         if CREATE_ANNOTATED_VIDEO and os.path.exists(local_output_path):


### PR DESCRIPTION
## Summary
- save processed video locally when not using SFTP
- document annotated video saving behavior in README

## Testing
- `pre-commit run --files utils/contagem_video.py README.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdc2ecbc248321bb82baa990bf7133