### PR TITLE
Use enum for video orientation validation

### DIFF
--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -44,7 +44,7 @@ Start processing a previously uploaded video.
 Required fields:
 
 - `nome_arquivo` (string): unique filename returned by `/upload-video/`.
-- `orientation` (string): one of `N`, `NE`, `E`, `SE`, `S`, `SW`, `W`, `NW`.
+- `orientation` (`Orientation` enum): one of `N`, `NE`, `E`, `SE`, `S`, `SW`, `W`, `NW`.
 - `line_position_ratio` (number between `0.0` and `1.0`, default `0.5`):
   counting line position for horizontal/vertical lines.
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,1 +1,301 @@
-{"openapi":"3.1.0","info":{"title":"CountG API","description":"FastAPI backend for counting and tracking objects in video.","version":"0.1.0"},"paths":{"/upload-video/":{"post":{"summary":"Upload Video Endpoint","description":"Português:\n    Recebe um vídeo do frontend, valida e salva temporariamente no servidor.\n\n    Parâmetros:\n        file (UploadFile): vídeo enviado pelo cliente.\n\n    Retorna:\n        dict: mensagem de sucesso e o nome único gerado para o vídeo.\n\n    Exemplo:\n        >>> curl -X POST -F \"file=@meu_video.mp4\" \\\n        ...     http://localhost:8000/upload-video/\n\nEnglish:\n    Receives a video from the frontend, validates it and stores it temporarily.\n\n    Parameters:\n        file (UploadFile): video provided by the client.\n\n    Returns:\n        dict: success message and the unique server-side filename.\n\n    Example:\n        >>> curl -X POST -F \"file=@my_video.mp4\" \\\n        ...     http://localhost:8000/upload-video/","operationId":"upload_video_endpoint_upload_video__post","requestBody":{"content":{"multipart/form-data":{"schema":{"$ref":"#/components/schemas/Body_upload_video_endpoint_upload_video__post"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/predict-video/":{"post":{"summary":"Predict Video Endpoint","description":"Português:\n    Inicia o processamento de um vídeo previamente enviado para contar o gado.\n\n    Parâmetros:\n        request (VideoRequest): dados do vídeo e opções de processamento.\n\n    Retorna:\n        dict: status indicando que o processamento foi iniciado.\n\n    Exemplo:\n        >>> curl -X POST -H \"Content-Type: application/json\" \\\n        ...     -d '{\"nome_arquivo\":\"video.mp4\"}' \\\n        ...     http://localhost:8000/predict-video/\n\nEnglish:\n    Starts cattle counting for a previously uploaded video.\n\n    Parameters:\n        request (VideoRequest): video data and processing options.\n\n    Returns:\n        dict: status informing that processing has begun.\n\n    Example:\n        >>> curl -X POST -H \"Content-Type: application/json\" \\\n        ...     -d '{\"nome_arquivo\":\"video.mp4\"}' \\\n        ...     http://localhost:8000/predict-video/","operationId":"predict_video_endpoint_predict_video__post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/VideoRequest"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/progresso/{video_name}":{"get":{"summary":"Progresso Endpoint","description":"Português:\n    Consulta o progresso do processamento de um vídeo.\n\n    Parâmetros:\n        video_name (str): nome do arquivo do vídeo no servidor.\n\n    Retorna:\n        dict: dados de status e porcentagem de conclusão.\n\n    Exemplo:\n        >>> curl http://localhost:8000/progresso/video.mp4\n\nEnglish:\n    Retrieves the processing progress for a video.\n\n    Parameters:\n        video_name (str): name of the video file on the server.\n\n    Returns:\n        dict: status data including completion percentage.\n\n    Example:\n        >>> curl http://localhost:8000/progresso/video.mp4","operationId":"progresso_endpoint_progresso__video_name__get","parameters":[{"name":"video_name","in":"path","required":true,"schema":{"type":"string","title":"Video Name"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/cancelar-processamento/{video_name}":{"get":{"summary":"Cancelar Endpoint","description":"Português:\n    Solicita o cancelamento do processamento de um vídeo.\n\n    Parâmetros:\n        video_name (str): nome do arquivo do vídeo no servidor.\n\n    Retorna:\n        dict: mensagem indicando se o cancelamento foi enviado.\n\n    Exemplo:\n        >>> curl http://localhost:8000/cancelar-processamento/video.mp4\n\nEnglish:\n    Requests cancellation of video processing.\n\n    Parameters:\n        video_name (str): name of the video file on the server.\n\n    Returns:\n        dict: message stating whether cancellation was issued.\n\n    Example:\n        >>> curl http://localhost:8000/cancelar-processamento/video.mp4","operationId":"cancelar_endpoint_cancelar_processamento__video_name__get","parameters":[{"name":"video_name","in":"path","required":true,"schema":{"type":"string","title":"Video Name"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/":{"get":{"summary":"Read Root","description":"Health check endpoint / Endpoint de verificação de saúde.\n\nEnglish:\n    Provides a quick indication that the backend is running and reports\n    whether the ``DATABASE_URL`` environment variable has been loaded.\n    ``database_url_loaded`` is ``True`` when ``DATABASE_URL`` is set,\n    otherwise ``False``.\n\nPortuguês:\n    Fornece uma indicação rápida de que o backend está ativo e informa\n    se a variável de ambiente ``DATABASE_URL`` foi carregada.\n    ``database_url_loaded`` é ``True`` quando ``DATABASE_URL`` está definida,\n    caso contrário ``False``.\n\nExample/Exemplo:\n    {\n        \"status\": \"KYO DAY Backend is running!\",\n        \"database_url_loaded\": true\n    }","operationId":"read_root__get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}}},"components":{"schemas":{"Body_upload_video_endpoint_upload_video__post":{"properties":{"file":{"type":"string","format":"binary","title":"File"}},"type":"object","required":["file"],"title":"Body_upload_video_endpoint_upload_video__post"},"HTTPValidationError":{"properties":{"detail":{"items":{"$ref":"#/components/schemas/ValidationError"},"type":"array","title":"Detail"}},"type":"object","title":"HTTPValidationError"},"ValidationError":{"properties":{"loc":{"items":{"anyOf":[{"type":"string"},{"type":"integer"}]},"type":"array","title":"Location"},"msg":{"type":"string","title":"Message"},"type":{"type":"string","title":"Error Type"}},"type":"object","required":["loc","msg","type"],"title":"ValidationError"},"VideoRequest":{"properties":{"nome_arquivo":{"type":"string","title":"Nome Arquivo","description":"O nome único do arquivo de vídeo que foi previamente enviado para o servidor.\nEnglish: The unique name of the video file that was previously uploaded to the server.","example":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.mp4"},"orientation":{"type":"string","title":"Orientation","description":"Orientação do movimento do gado: N, NE, E, SE, S, SW, W, NW.\nEnglish: Orientation of cattle movement: N, NE, E, SE, S, SW, W, NW.","example":"S"},"model_choice":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Model Choice","description":"Escolha do modelo YOLO: 'n' (nano), 'm' (médio), 'l' (grande), ou 'p' (próprio/best.pt).\nEnglish: YOLO model choice: 'n' (nano), 'm' (medium), 'l' (large), or 'p' (own/best.pt).","default":"l","example":"l"},"target_classes":{"anyOf":[{"items":{"type":"string"},"type":"array"},{"type":"null"}],"title":"Target Classes","description":"Lista de classes alvo para contagem. Se Nulo (None), todas as classes detectadas serão contadas.\nEnglish: List of target classes for counting. If Null (None), all detected classes will be counted.","example":["cow"]},"line_position_ratio":{"anyOf":[{"type":"number","maximum":1.0,"minimum":0.0},{"type":"null"}],"title":"Line Position Ratio","description":"Posição da linha de contagem para linhas Horizontais/Verticais (0.0 a 1.0).\nEnglish: Counting line position for Horizontal/Vertical lines (0.0 to 1.0).","default":0.5,"example":0.5}},"type":"object","required":["nome_arquivo","orientation"],"title":"VideoRequest","description":"Define a estrutura esperada para o corpo da requisição POST em /predict-video/.\n\nEnglish: Defines the expected structure for the POST request body at /predict-video/."}}}}
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/upload-video/": {
+      "post": {
+        "summary": "Upload Video Endpoint",
+        "description": "Português:\n    Recebe um vídeo do frontend, valida e salva temporariamente no servidor.\n\n    Parâmetros:\n        file (UploadFile): vídeo enviado pelo cliente.\n\n    Retorna:\n        dict: mensagem de sucesso e o nome único gerado para o vídeo.\n\n    Exemplo:\n        >>> curl -X POST -F \"file=@meu_video.mp4\" \\\n        ...     http://localhost:8000/upload-video/\n\nEnglish:\n    Receives a video from the frontend, validates it and stores it temporarily.\n\n    Parameters:\n        file (UploadFile): video provided by the client.\n\n    Returns:\n        dict: success message and the unique server-side filename.\n\n    Example:\n        >>> curl -X POST -F \"file=@my_video.mp4\" \\\n        ...     http://localhost:8000/upload-video/",
+        "operationId": "upload_video_endpoint_upload_video__post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_video_endpoint_upload_video__post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predict-video/": {
+      "post": {
+        "summary": "Predict Video Endpoint",
+        "description": "Português:\n    Inicia o processamento de um vídeo previamente enviado para contar o gado.\n\n    Parâmetros:\n        request (VideoRequest): dados do vídeo e opções de processamento.\n\n    Retorna:\n        dict: status indicando que o processamento foi iniciado.\n\n    Exemplo:\n        >>> curl -X POST -H \"Content-Type: application/json\" \\\n        ...     -d '{\"nome_arquivo\":\"video.mp4\"}' \\\n        ...     http://localhost:8000/predict-video/\n\nEnglish:\n    Starts cattle counting for a previously uploaded video.\n\n    Parameters:\n        request (VideoRequest): video data and processing options.\n\n    Returns:\n        dict: status informing that processing has begun.\n\n    Example:\n        >>> curl -X POST -H \"Content-Type: application/json\" \\\n        ...     -d '{\"nome_arquivo\":\"video.mp4\"}' \\\n        ...     http://localhost:8000/predict-video/",
+        "operationId": "predict_video_endpoint_predict_video__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VideoRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/progresso/{video_name}": {
+      "get": {
+        "summary": "Progresso Endpoint",
+        "description": "Português:\n    Consulta o progresso do processamento de um vídeo.\n\n    Parâmetros:\n        video_name (str): nome do arquivo do vídeo no servidor.\n\n    Retorna:\n        dict: dados de status e porcentagem de conclusão.\n\n    Exemplo:\n        >>> curl http://localhost:8000/progresso/video.mp4\n\nEnglish:\n    Retrieves the processing progress for a video.\n\n    Parameters:\n        video_name (str): name of the video file on the server.\n\n    Returns:\n        dict: status data including completion percentage.\n\n    Example:\n        >>> curl http://localhost:8000/progresso/video.mp4",
+        "operationId": "progresso_endpoint_progresso__video_name__get",
+        "parameters": [
+          {
+            "name": "video_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Video Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cancelar-processamento/{video_name}": {
+      "get": {
+        "summary": "Cancelar Endpoint",
+        "description": "Português:\n    Solicita o cancelamento do processamento de um vídeo.\n\n    Parâmetros:\n        video_name (str): nome do arquivo do vídeo no servidor.\n\n    Retorna:\n        dict: mensagem indicando se o cancelamento foi enviado.\n\n    Exemplo:\n        >>> curl http://localhost:8000/cancelar-processamento/video.mp4\n\nEnglish:\n    Requests cancellation of video processing.\n\n    Parameters:\n        video_name (str): name of the video file on the server.\n\n    Returns:\n        dict: message stating whether cancellation was issued.\n\n    Example:\n        >>> curl http://localhost:8000/cancelar-processamento/video.mp4",
+        "operationId": "cancelar_endpoint_cancelar_processamento__video_name__get",
+        "parameters": [
+          {
+            "name": "video_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Video Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Body_upload_video_endpoint_upload_video__post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_upload_video_endpoint_upload_video__post"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "Orientation": {
+        "type": "string",
+        "enum": [
+          "N",
+          "NE",
+          "E",
+          "SE",
+          "S",
+          "SW",
+          "W",
+          "NW"
+        ],
+        "title": "Orientation",
+        "description": "Allowed orientation codes."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "VideoRequest": {
+        "properties": {
+          "nome_arquivo": {
+            "type": "string",
+            "title": "Nome Arquivo",
+            "description": "O nome único do arquivo de vídeo que foi previamente enviado para o servidor.\nEnglish: The unique name of the video file that was previously uploaded to the server.",
+            "example": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.mp4"
+          },
+          "orientation": {
+            "$ref": "#/components/schemas/Orientation",
+            "description": "Orientação do movimento do gado: N, NE, E, SE, S, SW, W, NW.\nEnglish: Orientation of cattle movement: N, NE, E, SE, S, SW, W, NW.",
+            "example": "S"
+          },
+          "model_choice": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Choice",
+            "description": "Escolha do modelo YOLO: 'n' (nano), 'm' (médio), 'l' (grande), ou 'p' (próprio/best.pt).\nEnglish: YOLO model choice: 'n' (nano), 'm' (medium), 'l' (large), or 'p' (own/best.pt).",
+            "default": "l",
+            "example": "l"
+          },
+          "target_classes": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Classes",
+            "description": "Lista de classes alvo para contagem. Se Nulo (None), todas as classes detectadas serão contadas.\nEnglish: List of target classes for counting. If Null (None), all detected classes will be counted.",
+            "example": [
+              "cow"
+            ]
+          },
+          "line_position_ratio": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Line Position Ratio",
+            "description": "Posição da linha de contagem para linhas Horizontais/Verticais (0.0 a 1.0).\nEnglish: Counting line position for Horizontal/Vertical lines (0.0 to 1.0).",
+            "default": 0.5,
+            "example": 0.5
+          }
+        },
+        "type": "object",
+        "required": [
+          "nome_arquivo",
+          "orientation"
+        ],
+        "title": "VideoRequest",
+        "description": "Define a estrutura esperada para o corpo da requisição POST em /predict-video/.\n\nEnglish: Defines the expected structure for the POST request body at /predict-video/."
+      }
+    }
+  }
+}

--- a/docs/pt/api-reference.md
+++ b/docs/pt/api-reference.md
@@ -43,7 +43,7 @@ Inicia o processamento de um vídeo previamente enviado.
 **Campos obrigatórios**
 
 - `nome_arquivo` (string): nome único do vídeo enviado.
-- `orientation` (string): direção do movimento; valores possíveis: `N`, `NE`, `E`, `SE`, `S`, `SW`, `W`, `NW`.
+- `orientation` (`Orientation` enum): direção do movimento; valores possíveis: `N`, `NE`, `E`, `SE`, `S`, `SW`, `W`, `NW`.
 - `line_position_ratio` (número entre `0.0` e `1.0`, padrão `0.5`): posição da linha de contagem.
 
 **Campos opcionais**

--- a/schemas.py
+++ b/schemas.py
@@ -1,9 +1,23 @@
+from enum import Enum
 from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
 # BaseModel é a classe base do Pydantic para criar modelos de dados.
 # Field é usado para adicionar metadados extras aos campos, como exemplos, descrições e validações.
+
+
+class Orientation(str, Enum):
+    """Allowed orientation codes."""
+
+    N = "N"
+    NE = "NE"
+    E = "E"
+    SE = "SE"
+    S = "S"
+    SW = "SW"
+    W = "W"
+    NW = "NW"
 
 
 class VideoRequest(BaseModel):
@@ -24,7 +38,7 @@ class VideoRequest(BaseModel):
     )
 
     # Campo obrigatório: orientação do movimento do gado
-    orientation: str = Field(
+    orientation: Orientation = Field(
         ...,
         example="S",
         description=(

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -10,6 +10,7 @@ accepts videos with permitted extensions.
 """
 
 import os
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -42,7 +43,9 @@ def test_upload_video_endpoint_accepts_valid_extension(tmp_path):
 
     # Reload module to apply new DATA_DIR
     from importlib import reload
+
     import routes.video_routes as video_routes
+
     reload(video_routes)
 
     app = FastAPI()
@@ -57,3 +60,14 @@ def test_upload_video_endpoint_accepts_valid_extension(tmp_path):
     nome_arquivo = response.json()["nome_arquivo"]
     saved_path = uploads_dir / nome_arquivo
     assert saved_path.exists()
+
+
+def test_predict_video_endpoint_rejects_invalid_orientation():
+    """Return 422 when orientation is outside allowed enum."""
+
+    client = TestClient(app)
+    response = client.post(
+        "/predict-video/",
+        json={"nome_arquivo": "video.mp4", "orientation": "INVALID"},
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- introduce `Orientation` enum and apply it to `VideoRequest.orientation` for automatic FastAPI validation
- document enum-based orientation in API references and regenerate OpenAPI schema
- add test to ensure invalid orientation values are rejected

## Testing
- `python -m pre_commit run --files schemas.py tests/test_routes.py docs/en/api-reference.md docs/pt/api-reference.md docs/openapi.json`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68beb62a961c8321931b4cf9f08eb275