### PR TITLE
Validate orientation codes for video processing

### DIFF
--- a/routes/video_routes.py
+++ b/routes/video_routes.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import JSONResponse
 
 from schemas import VideoRequest
-from utils.contagem_video import contar_gado_em_video
+from utils.contagem_video import contar_gado_em_video, get_line_and_direction_config
 from utils.gerenciador_progresso import ProgressoManager
 
 router = APIRouter()
@@ -154,6 +154,11 @@ async def predict_video_endpoint(request: VideoRequest):
     upload_folder_abs = os.path.abspath(UPLOAD_FOLDER)
     if not abs_path.startswith(upload_folder_abs + os.sep):
         raise HTTPException(status_code=400, detail="Nome de arquivo inválido.")
+
+    try:
+        get_line_and_direction_config(request.orientation, 1, 1)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid orientation code.")
 
     if progresso_manager.is_processing(video_name_on_server):
         logger.warning(

--- a/schemas.py
+++ b/schemas.py
@@ -38,7 +38,7 @@ class VideoRequest(BaseModel):
     )
 
     # Campo obrigatório: orientação do movimento do gado
-    orientation: Orientation = Field(
+    orientation: str = Field(
         ...,
         example="S",
         description=(

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -63,11 +63,31 @@ def test_upload_video_endpoint_accepts_valid_extension(tmp_path):
 
 
 def test_predict_video_endpoint_rejects_invalid_orientation():
-    """Return 422 when orientation is outside allowed enum."""
+    """Return 400 when orientation code is invalid."""
 
     client = TestClient(app)
     response = client.post(
         "/predict-video/",
         json={"nome_arquivo": "video.mp4", "orientation": "INVALID"},
     )
-    assert response.status_code == 422
+    assert response.status_code == 400
+
+
+def test_predict_video_endpoint_accepts_valid_orientation(monkeypatch):
+    """Accept a valid orientation and start processing."""
+
+    client = TestClient(app)
+
+    def fake_contar_gado_em_video(**kwargs):
+        return {}
+
+    monkeypatch.setattr(
+        "routes.video_routes.contar_gado_em_video", fake_contar_gado_em_video
+    )
+
+    response = client.post(
+        "/predict-video/",
+        json={"nome_arquivo": "video.mp4", "orientation": "N"},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "iniciado"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,7 @@ from utils.contagem_video import (
     is_crossing_diagonal_line,
     MOVE_TL_BR,
 )
+import pytest
 
 
 def test_get_line_and_direction_config_east():
@@ -28,6 +29,13 @@ def test_get_line_and_direction_config_east():
     assert direction == MOVE_LR
     assert line_points == ((50, 0), (50, 50))
     assert pos == 50
+
+
+def test_get_line_and_direction_config_invalid_orientation():
+    """Raise ValueError for unsupported orientation codes."""
+
+    with pytest.raises(ValueError):
+        get_line_and_direction_config("INVALID", width=100, height=50)
 
 
 def test_is_crossing_diagonal_line():

--- a/utils/contagem_video.py
+++ b/utils/contagem_video.py
@@ -53,12 +53,12 @@ def get_line_and_direction_config(
         ``(line_type, direction, line_points, line_pos_value, arrow_points)``.
 
     Efeitos colaterais / Side Effects:
-        Emite mensagens de log quando a orientação é desconhecida.
-        Logs a warning when the orientation is unknown.
+        Nenhum.
+        None.
 
     Exceções / Exceptions:
-        Nenhuma é lançada explicitamente.
-        None are explicitly raised.
+        ValueError: Lançada quando a orientação é desconhecida.
+        ValueError: Raised when the orientation is unknown.
     """
     (
         line_type,
@@ -127,17 +127,9 @@ def get_line_and_direction_config(
             (width // 4, 3 * height // 4),
         )
     else:
-        logger.warning(
-            f"[AVISO get_line_config] Orientação '{orientation_code}' desconhecida. Usando padrão Leste (E)."
-        )
-        line_type = LINE_VERTICAL
-        effective_counting_direction = MOVE_LR
-        line_pos_value = int(width * line_ratio)
-        line_points = ((line_pos_value, 0), (line_pos_value, height))
-        arrow_points = (
-            (line_pos_value - arrow_offset, height // 2),
-            (line_pos_value + arrow_offset, height // 2),
-        )
+        msg = f"[AVISO get_line_config] Orientação '{orientation_code}' desconhecida."
+        logger.warning(msg)
+        raise ValueError(msg)
 
     logger.debug(
         f"[get_line_config] Para '{orientation_code}': tipo={line_type}, dir={effective_counting_direction}"


### PR DESCRIPTION
## Summary
- Raise `ValueError` for unknown orientation codes in `get_line_and_direction_config`
- Validate orientation in `predict_video_endpoint` and return HTTP 400 on invalid input
- Add tests for valid and invalid orientation handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bebbe543e08321bfbbbf95819c8796