### PR TITLE
Handle video rotation metadata before processing

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,3 +1,5 @@
 # CountG Overview
 
 CountG is a FastAPI backend for counting and tracking objects in video using YOLOv8 models. This documentation covers environment setup and a full API reference. Use the language selector at the top right to switch between English and Portuguese.
+
+Video rotation metadata is inspected and frames are automatically rotated before counting.

--- a/docs/pt/index.md
+++ b/docs/pt/index.md
@@ -1,3 +1,5 @@
 # Visão Geral do CountG
 
 CountG é um backend em FastAPI para contagem e rastreamento de objetos em vídeo utilizando modelos YOLOv8. Esta documentação aborda a configuração do ambiente e uma referência completa da API. Use o seletor de idioma no canto superior direito para alternar entre Português e Inglês.
+
+Os metadados de rotação dos vídeos são inspecionados e os frames são rotacionados automaticamente antes da contagem.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,21 +9,28 @@ The module validates line and direction configuration and detection of
 diagonal line crossings.
 """
 
-from utils.contagem_video import (
-    get_line_and_direction_config,
+import subprocess
+from types import SimpleNamespace
+
+import cv2
+import pytest
+
+from utils.contagem_video import (  # isort: skip
     LINE_VERTICAL,
     MOVE_LR,
-    is_crossing_diagonal_line,
     MOVE_TL_BR,
+    apply_rotation,
+    get_line_and_direction_config,
+    get_video_rotation,
+    is_crossing_diagonal_line,
 )
-import pytest
 
 
 def test_get_line_and_direction_config_east():
     """Return a centered vertical line moving from left to right for east."""
 
     line_type, direction, line_points, pos, _ = get_line_and_direction_config(
-        'E', width=100, height=50
+        "E", width=100, height=50
     )
     assert line_type == LINE_VERTICAL
     assert direction == MOVE_LR
@@ -46,8 +53,60 @@ def test_is_crossing_diagonal_line():
     line_p1 = (0, 0)
     line_p2 = (100, 100)
     crossed = is_crossing_diagonal_line(
-        p_prev[0], p_prev[1],
-        p_curr[0], p_curr[1],
-        line_p1, line_p2, MOVE_TL_BR,
+        p_prev[0],
+        p_prev[1],
+        p_curr[0],
+        p_curr[1],
+        line_p1,
+        line_p2,
+        MOVE_TL_BR,
     )
     assert crossed is True
+
+
+def test_rotation_metadata_and_application(tmp_path, monkeypatch):
+    """Rotate frame based on metadata / Rotaciona frame segundo metadados."""
+
+    video_file = tmp_path / "rot90.mp4"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=size=40x20:rate=1",
+            "-t",
+            "1",
+            str(video_file),
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    def fake_run(cmd, stdout, stderr, text, check):
+        return SimpleNamespace(stdout="90")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    rotation = get_video_rotation(str(video_file))
+    assert rotation == 90
+
+    frame = [[0] * 40 for _ in range(20)]
+
+    def fake_rotate(f, code):
+        if code == cv2.ROTATE_90_CLOCKWISE:
+            return [list(row) for row in zip(*f[::-1])]
+        if code == cv2.ROTATE_180:
+            return [row[::-1] for row in f[::-1]]
+        if code == cv2.ROTATE_90_COUNTERCLOCKWISE:
+            return [list(row) for row in zip(*f)][::-1]
+        return f
+
+    monkeypatch.setattr(cv2, "ROTATE_90_CLOCKWISE", 0, raising=False)
+    monkeypatch.setattr(cv2, "ROTATE_180", 1, raising=False)
+    monkeypatch.setattr(cv2, "ROTATE_90_COUNTERCLOCKWISE", 2, raising=False)
+    monkeypatch.setattr(cv2, "rotate", fake_rotate, raising=False)
+
+    rotated = apply_rotation(frame, rotation)
+    assert len(rotated) == 40 and len(rotated[0]) == 20

--- a/utils/contagem_video.py
+++ b/utils/contagem_video.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import logging
 import os
+import subprocess
 from collections import defaultdict
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -23,6 +26,64 @@ MOVE_TL_BR: str = "topleft_bottomright"
 MOVE_BR_TL: str = "bottomright_topleft"
 MOVE_TR_BL: str = "topright_bottomleft"
 MOVE_BL_TR: str = "bottomleft_topright"
+
+
+def get_video_rotation(video_path: str) -> int:
+    """Retrieve rotation metadata / Obtém metadados de rotação.
+
+    English:
+        Runs ``ffprobe`` to read the ``rotate`` tag from the first video
+        stream. Returns the rotation angle in degrees (0, 90, 180 or 270).
+
+    Português:
+        Executa ``ffprobe`` para ler a tag ``rotate`` do primeiro stream de
+        vídeo. Retorna o ângulo de rotação em graus (0, 90, 180 ou 270).
+    """
+
+    try:
+        cmd = [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream_tags=rotate",
+            "-of",
+            "default=nw=1:nk=1",
+            video_path,
+        ]
+        result = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+        rotation = int(result.stdout.strip())
+        return rotation % 360
+    except Exception as e:  # pragma: no cover - fallback in case of failure
+        logger.debug("Rotation metadata not found or ffprobe failed: %s", e)
+        return 0
+
+
+def apply_rotation(frame: np.ndarray, rotation: int) -> np.ndarray:
+    """Rotate frame according to metadata / Rotaciona frame de acordo com metadados.
+
+    English:
+        Rotates the frame using OpenCV based on the rotation angle.
+
+    Português:
+        Rotaciona o frame utilizando OpenCV conforme o ângulo informado.
+    """
+
+    if rotation == 90:
+        return cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
+    if rotation == 180:
+        return cv2.rotate(frame, cv2.ROTATE_180)
+    if rotation == 270:
+        return cv2.rotate(frame, cv2.ROTATE_90_COUNTERCLOCKWISE)
+    return frame
 
 
 def get_line_and_direction_config(
@@ -215,7 +276,11 @@ def contar_gado_em_video(
 ) -> Optional[Dict[str, Any]]:
     """Realiza a contagem de gado em um arquivo de vídeo.
 
-    Count cattle in a video file.
+    Count cattle in a video file. Frames are rotated according to rotation
+    metadata before processing.
+
+    Os frames são rotacionados conforme metadados de rotação antes do
+    processamento.
 
     Parâmetros / Parameters:
         video_path (str): Caminho local para o vídeo.
@@ -331,11 +396,14 @@ def contar_gado_em_video(
             progresso_manager.erro(video_name, "Falha ao abrir o arquivo de vídeo.")
         return None
 
+    rotation = get_video_rotation(local_video_path)
     original_frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
     fps = cap.get(cv2.CAP_PROP_FPS)
     _fps = fps if fps > 0 else 30.0
     width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
     height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    if rotation in (90, 270):
+        width, height = height, width
 
     if width == 0 or height == 0:
         if progresso_manager:
@@ -405,6 +473,9 @@ def contar_gado_em_video(
         ret, frame = cap.read()
         if not ret:
             break
+
+        if rotation:
+            frame = apply_rotation(frame, rotation)
 
         if frame_atual % frame_skip == 0:
             if not progresso_manager.atualizar(


### PR DESCRIPTION
## Summary
- inspect video rotation metadata via ffprobe before processing
- rotate frames according to metadata and update docs
- test rotation handling with a mocked ffprobe result

## Testing
- `pre-commit run --files utils/contagem_video.py tests/test_utils.py docs/pt/index.md docs/en/index.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bec0a0a8008321889f63d0303ff0d4