### PR TITLE
Add orientation map endpoint and documentation

### DIFF
--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -18,6 +18,21 @@ favorite API explorer.
 curl http://localhost:8000/
 ```
 
+## `GET /orientation-map`
+Retrieve the list of orientation codes with human-friendly labels and arrow
+symbols. Useful for building a directional selector in the UI.
+
+**Response**
+```json
+{
+  "N": {"label": "North", "arrow": "\u2191"},
+  "S": {"label": "South", "arrow": "\u2193"}
+}
+```
+```bash
+curl http://localhost:8000/orientation-map
+```
+
 ## `POST /upload-video/`
 Upload a video file. Supported formats: `.mp4`, `.mov`, `.avi`, `.mkv`. The
 maximum allowed size is **500 MB**.
@@ -44,7 +59,7 @@ Start processing a previously uploaded video.
 Required fields:
 
 - `nome_arquivo` (string): unique filename returned by `/upload-video/`.
-- `orientation` (`Orientation` enum): one of `N`, `NE`, `E`, `SE`, `S`, `SW`, `W`, `NW`.
+- `orientation` (`Orientation` enum): one of `N`, `NE`, `E`, `SE`, `S`, `SW`, `W`, `NW`. Use [`GET /orientation-map`](#get-orientation-map) to display these options in the UI.
 - `line_position_ratio` (number between `0.0` and `1.0`, default `0.5`):
   counting line position for horizontal/vertical lines.
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,14 +1,15 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "FastAPI",
+    "title": "CountG API",
+    "description": "FastAPI backend for counting and tracking objects in video.",
     "version": "0.1.0"
   },
   "paths": {
     "/upload-video/": {
       "post": {
         "summary": "Upload Video Endpoint",
-        "description": "Português:\n    Recebe um vídeo do frontend, valida e salva temporariamente no servidor.\n\n    Parâmetros:\n        file (UploadFile): vídeo enviado pelo cliente.\n\n    Retorna:\n        dict: mensagem de sucesso e o nome único gerado para o vídeo.\n\n    Exemplo:\n        >>> curl -X POST -F \"file=@meu_video.mp4\" \\\n        ...     http://localhost:8000/upload-video/\n\nEnglish:\n    Receives a video from the frontend, validates it and stores it temporarily.\n\n    Parameters:\n        file (UploadFile): video provided by the client.\n\n    Returns:\n        dict: success message and the unique server-side filename.\n\n    Example:\n        >>> curl -X POST -F \"file=@my_video.mp4\" \\\n        ...     http://localhost:8000/upload-video/",
+        "description": "Portugu\u00eas:\n    Recebe um v\u00eddeo do frontend, valida e salva temporariamente no servidor.\n\n    Par\u00e2metros:\n        file (UploadFile): v\u00eddeo enviado pelo cliente.\n\n    Retorna:\n        dict: mensagem de sucesso e o nome \u00fanico gerado para o v\u00eddeo.\n\n    Exemplo:\n        >>> curl -X POST -F \"file=@meu_video.mp4\" \\\n        ...     http://localhost:8000/upload-video/\n\nEnglish:\n    Receives a video from the frontend, validates it and stores it temporarily.\n\n    Parameters:\n        file (UploadFile): video provided by the client.\n\n    Returns:\n        dict: success message and the unique server-side filename.\n\n    Example:\n        >>> curl -X POST -F \"file=@my_video.mp4\" \\\n        ...     http://localhost:8000/upload-video/",
         "operationId": "upload_video_endpoint_upload_video__post",
         "requestBody": {
           "content": {
@@ -45,7 +46,7 @@
     "/predict-video/": {
       "post": {
         "summary": "Predict Video Endpoint",
-        "description": "Português:\n    Inicia o processamento de um vídeo previamente enviado para contar o gado.\n\n    Parâmetros:\n        request (VideoRequest): dados do vídeo e opções de processamento.\n\n    Retorna:\n        dict: status indicando que o processamento foi iniciado.\n\n    Exemplo:\n        >>> curl -X POST -H \"Content-Type: application/json\" \\\n        ...     -d '{\"nome_arquivo\":\"video.mp4\"}' \\\n        ...     http://localhost:8000/predict-video/\n\nEnglish:\n    Starts cattle counting for a previously uploaded video.\n\n    Parameters:\n        request (VideoRequest): video data and processing options.\n\n    Returns:\n        dict: status informing that processing has begun.\n\n    Example:\n        >>> curl -X POST -H \"Content-Type: application/json\" \\\n        ...     -d '{\"nome_arquivo\":\"video.mp4\"}' \\\n        ...     http://localhost:8000/predict-video/",
+        "description": "Portugu\u00eas:\n    Inicia o processamento de um v\u00eddeo previamente enviado para contar o gado.\n\n    Par\u00e2metros:\n        request (VideoRequest): dados do v\u00eddeo e op\u00e7\u00f5es de processamento.\n\n    Retorna:\n        dict: status indicando que o processamento foi iniciado.\n\n    Exemplo:\n        >>> curl -X POST -H \"Content-Type: application/json\" \\\n        ...     -d '{\"nome_arquivo\":\"video.mp4\"}' \\\n        ...     http://localhost:8000/predict-video/\n\nEnglish:\n    Starts cattle counting for a previously uploaded video.\n\n    Parameters:\n        request (VideoRequest): video data and processing options.\n\n    Returns:\n        dict: status informing that processing has begun.\n\n    Example:\n        >>> curl -X POST -H \"Content-Type: application/json\" \\\n        ...     -d '{\"nome_arquivo\":\"video.mp4\"}' \\\n        ...     http://localhost:8000/predict-video/",
         "operationId": "predict_video_endpoint_predict_video__post",
         "requestBody": {
           "content": {
@@ -82,7 +83,7 @@
     "/progresso/{video_name}": {
       "get": {
         "summary": "Progresso Endpoint",
-        "description": "Português:\n    Consulta o progresso do processamento de um vídeo.\n\n    Parâmetros:\n        video_name (str): nome do arquivo do vídeo no servidor.\n\n    Retorna:\n        dict: dados de status e porcentagem de conclusão.\n\n    Exemplo:\n        >>> curl http://localhost:8000/progresso/video.mp4\n\nEnglish:\n    Retrieves the processing progress for a video.\n\n    Parameters:\n        video_name (str): name of the video file on the server.\n\n    Returns:\n        dict: status data including completion percentage.\n\n    Example:\n        >>> curl http://localhost:8000/progresso/video.mp4",
+        "description": "Portugu\u00eas:\n    Consulta o progresso do processamento de um v\u00eddeo.\n\n    Par\u00e2metros:\n        video_name (str): nome do arquivo do v\u00eddeo no servidor.\n\n    Retorna:\n        dict: dados de status e porcentagem de conclus\u00e3o.\n\n    Exemplo:\n        >>> curl http://localhost:8000/progresso/video.mp4\n\nEnglish:\n    Retrieves the processing progress for a video.\n\n    Parameters:\n        video_name (str): name of the video file on the server.\n\n    Returns:\n        dict: status data including completion percentage.\n\n    Example:\n        >>> curl http://localhost:8000/progresso/video.mp4",
         "operationId": "progresso_endpoint_progresso__video_name__get",
         "parameters": [
           {
@@ -120,7 +121,7 @@
     "/cancelar-processamento/{video_name}": {
       "get": {
         "summary": "Cancelar Endpoint",
-        "description": "Português:\n    Solicita o cancelamento do processamento de um vídeo.\n\n    Parâmetros:\n        video_name (str): nome do arquivo do vídeo no servidor.\n\n    Retorna:\n        dict: mensagem indicando se o cancelamento foi enviado.\n\n    Exemplo:\n        >>> curl http://localhost:8000/cancelar-processamento/video.mp4\n\nEnglish:\n    Requests cancellation of video processing.\n\n    Parameters:\n        video_name (str): name of the video file on the server.\n\n    Returns:\n        dict: message stating whether cancellation was issued.\n\n    Example:\n        >>> curl http://localhost:8000/cancelar-processamento/video.mp4",
+        "description": "Portugu\u00eas:\n    Solicita o cancelamento do processamento de um v\u00eddeo.\n\n    Par\u00e2metros:\n        video_name (str): nome do arquivo do v\u00eddeo no servidor.\n\n    Retorna:\n        dict: mensagem indicando se o cancelamento foi enviado.\n\n    Exemplo:\n        >>> curl http://localhost:8000/cancelar-processamento/video.mp4\n\nEnglish:\n    Requests cancellation of video processing.\n\n    Parameters:\n        video_name (str): name of the video file on the server.\n\n    Returns:\n        dict: message stating whether cancellation was issued.\n\n    Example:\n        >>> curl http://localhost:8000/cancelar-processamento/video.mp4",
         "operationId": "cancelar_endpoint_cancelar_processamento__video_name__get",
         "parameters": [
           {
@@ -149,6 +150,40 @@
                 "schema": {
                   "$ref": "#/components/schemas/HTTPValidationError"
                 }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/orientation-map": {
+      "get": {
+        "summary": "Get Orientation Map",
+        "description": "Return static orientation codes with labels and arrows.",
+        "operationId": "get_orientation_map_orientation_map_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "summary": "Read Root",
+        "description": "Health check endpoint / Endpoint de verifica\u00e7\u00e3o de sa\u00fade.\n\nEnglish:\n    Provides a quick indication that the backend is running and reports\n    whether the ``DATABASE_URL`` environment variable has been loaded.\n    ``database_url_loaded`` is ``True`` when ``DATABASE_URL`` is set,\n    otherwise ``False``.\n\nPortugu\u00eas:\n    Fornece uma indica\u00e7\u00e3o r\u00e1pida de que o backend est\u00e1 ativo e informa\n    se a vari\u00e1vel de ambiente ``DATABASE_URL`` foi carregada.\n    ``database_url_loaded`` \u00e9 ``True`` quando ``DATABASE_URL`` est\u00e1 definida,\n    caso contr\u00e1rio ``False``.\n\nExample/Exemplo:\n    {\n        \"status\": \"KYO DAY Backend is running!\",\n        \"database_url_loaded\": true\n    }",
+        "operationId": "read_root__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
               }
             }
           }
@@ -184,21 +219,6 @@
         },
         "type": "object",
         "title": "HTTPValidationError"
-      },
-      "Orientation": {
-        "type": "string",
-        "enum": [
-          "N",
-          "NE",
-          "E",
-          "SE",
-          "S",
-          "SW",
-          "W",
-          "NW"
-        ],
-        "title": "Orientation",
-        "description": "Allowed orientation codes."
       },
       "ValidationError": {
         "properties": {
@@ -238,12 +258,13 @@
           "nome_arquivo": {
             "type": "string",
             "title": "Nome Arquivo",
-            "description": "O nome único do arquivo de vídeo que foi previamente enviado para o servidor.\nEnglish: The unique name of the video file that was previously uploaded to the server.",
+            "description": "O nome \u00fanico do arquivo de v\u00eddeo que foi previamente enviado para o servidor.\nEnglish: The unique name of the video file that was previously uploaded to the server.",
             "example": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.mp4"
           },
           "orientation": {
-            "$ref": "#/components/schemas/Orientation",
-            "description": "Orientação do movimento do gado: N, NE, E, SE, S, SW, W, NW.\nEnglish: Orientation of cattle movement: N, NE, E, SE, S, SW, W, NW.",
+            "type": "string",
+            "title": "Orientation",
+            "description": "Orienta\u00e7\u00e3o do movimento do gado: N, NE, E, SE, S, SW, W, NW.\nEnglish: Orientation of cattle movement: N, NE, E, SE, S, SW, W, NW.",
             "example": "S"
           },
           "model_choice": {
@@ -256,7 +277,7 @@
               }
             ],
             "title": "Model Choice",
-            "description": "Escolha do modelo YOLO: 'n' (nano), 'm' (médio), 'l' (grande), ou 'p' (próprio/best.pt).\nEnglish: YOLO model choice: 'n' (nano), 'm' (medium), 'l' (large), or 'p' (own/best.pt).",
+            "description": "Escolha do modelo YOLO: 'n' (nano), 'm' (m\u00e9dio), 'l' (grande), ou 'p' (pr\u00f3prio/best.pt).\nEnglish: YOLO model choice: 'n' (nano), 'm' (medium), 'l' (large), or 'p' (own/best.pt).",
             "default": "l",
             "example": "l"
           },
@@ -273,7 +294,7 @@
               }
             ],
             "title": "Target Classes",
-            "description": "Lista de classes alvo para contagem. Se Nulo (None), todas as classes detectadas serão contadas.\nEnglish: List of target classes for counting. If Null (None), all detected classes will be counted.",
+            "description": "Lista de classes alvo para contagem. Se Nulo (None), todas as classes detectadas ser\u00e3o contadas.\nEnglish: List of target classes for counting. If Null (None), all detected classes will be counted.",
             "example": [
               "cow"
             ]
@@ -283,7 +304,7 @@
             "maximum": 1.0,
             "minimum": 0.0,
             "title": "Line Position Ratio",
-            "description": "Posição da linha de contagem para linhas Horizontais/Verticais (0.0 a 1.0).\nEnglish: Counting line position for Horizontal/Vertical lines (0.0 to 1.0).",
+            "description": "Posi\u00e7\u00e3o da linha de contagem para linhas Horizontais/Verticais (0.0 a 1.0).\nEnglish: Counting line position for Horizontal/Vertical lines (0.0 to 1.0).",
             "default": 0.5,
             "example": 0.5
           }
@@ -294,7 +315,7 @@
           "orientation"
         ],
         "title": "VideoRequest",
-        "description": "Define a estrutura esperada para o corpo da requisição POST em /predict-video/.\n\nEnglish: Defines the expected structure for the POST request body at /predict-video/."
+        "description": "Define a estrutura esperada para o corpo da requisi\u00e7\u00e3o POST em /predict-video/.\n\nEnglish: Defines the expected structure for the POST request body at /predict-video/."
       }
     }
   }

--- a/docs/pt/api-reference.md
+++ b/docs/pt/api-reference.md
@@ -18,6 +18,21 @@ utilize o link no seu explorador de APIs preferido.
 curl http://localhost:8000/
 ```
 
+## `GET /orientation-map`
+Retorna o mapeamento dos códigos de orientação com rótulos legíveis e setas.
+Útil para construir um seletor visual no frontend.
+
+**Resposta**
+```json
+{
+  "N": {"label": "North", "arrow": "\u2191"},
+  "S": {"label": "South", "arrow": "\u2193"}
+}
+```
+```bash
+curl http://localhost:8000/orientation-map
+```
+
 ## `POST /upload-video/`
 Envia um arquivo de vídeo.
 
@@ -43,7 +58,7 @@ Inicia o processamento de um vídeo previamente enviado.
 **Campos obrigatórios**
 
 - `nome_arquivo` (string): nome único do vídeo enviado.
-- `orientation` (`Orientation` enum): direção do movimento; valores possíveis: `N`, `NE`, `E`, `SE`, `S`, `SW`, `W`, `NW`.
+- `orientation` (`Orientation` enum): direção do movimento; valores possíveis: `N`, `NE`, `E`, `SE`, `S`, `SW`, `W`, `NW`. Use [`GET /orientation-map`](#get-orientation-map) para exibir essas opções na interface.
 - `line_position_ratio` (número entre `0.0` e `1.0`, padrão `0.5`): posição da linha de contagem.
 
 **Campos opcionais**

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ load_dotenv()
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from routes import video_routes
+from routes import orientation_routes, video_routes
 
 # --- CRITICAL STEP: LOAD ENVIRONMENT VARIABLES FIRST! ---
 # This call must be one of the first lines of your entry point before importing
@@ -44,6 +44,7 @@ app.add_middleware(
 
 # Include routes from video_routes.py
 app.include_router(video_routes.router)
+app.include_router(orientation_routes.router)
 
 
 # Root endpoint for health check

--- a/orientation_map.json
+++ b/orientation_map.json
@@ -1,0 +1,10 @@
+{
+  "N": {"label": "North", "arrow": "\u2191"},
+  "NE": {"label": "Northeast", "arrow": "\u2197"},
+  "E": {"label": "East", "arrow": "\u2192"},
+  "SE": {"label": "Southeast", "arrow": "\u2198"},
+  "S": {"label": "South", "arrow": "\u2193"},
+  "SW": {"label": "Southwest", "arrow": "\u2199"},
+  "W": {"label": "West", "arrow": "\u2190"},
+  "NW": {"label": "Northwest", "arrow": "\u2196"}
+}

--- a/routes/orientation_routes.py
+++ b/routes/orientation_routes.py
@@ -1,0 +1,22 @@
+import json
+import os
+
+from fastapi import APIRouter, HTTPException
+
+router = APIRouter()
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+ORIENTATION_FILE = os.path.join(BASE_DIR, "orientation_map.json")
+
+
+@router.get("/orientation-map")
+def get_orientation_map():
+    """Return static orientation codes with labels and arrows."""
+    try:
+        with open(ORIENTATION_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=500, detail="orientation_map.json not found"
+        ) from exc
+    return data

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -14,10 +14,12 @@ import os
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from routes.video_routes import router
+from routes.orientation_routes import router as orientation_router
+from routes.video_routes import router as video_router
 
 app = FastAPI()
-app.include_router(router)
+app.include_router(video_router)
+app.include_router(orientation_router)
 
 
 def test_upload_video_endpoint_rejects_invalid_extension():
@@ -91,3 +93,13 @@ def test_predict_video_endpoint_accepts_valid_orientation(monkeypatch):
     )
     assert response.status_code == 200
     assert response.json()["status"] == "iniciado"
+
+
+def test_orientation_map_endpoint_returns_map():
+    """Orientation map endpoint should return mapping with arrow symbols."""
+    client = TestClient(app)
+    response = client.get("/orientation-map")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["N"]["label"] == "North"
+    assert data["S"]["arrow"] == "\u2193"


### PR DESCRIPTION
## Summary
- add static `orientation_map.json` for mapping orientation codes to labels and arrows
- expose `GET /orientation-map` endpoint to serve map and wire into app
- document orientation map usage for UI developers in English and Portuguese API docs

## Testing
- `pre-commit run --files orientation_map.json routes/orientation_routes.py main.py docs/en/api-reference.md docs/pt/api-reference.md docs/openapi.json tests/test_routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bedccc28048321ac0d271dfc90b58b