### PR TITLE
Restrict orientation to cardinal directions

### DIFF
--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -59,7 +59,7 @@ Start processing a previously uploaded video.
 Required fields:
 
 - `nome_arquivo` (string): unique filename returned by `/upload-video/`.
-- `orientation` (`Orientation` enum): one of `N`, `NE`, `E`, `SE`, `S`, `SW`, `W`, `NW`. Use [`GET /orientation-map`](#get-orientation-map) to display these options in the UI.
+- `orientation` (`Orientation` enum): one of `N`, `E`, `S`, `W`. Use [`GET /orientation-map`](#get-orientation-map) to display these options in the UI.
 - `line_position_ratio` (number between `0.0` and `1.0`, default `0.5`):
   counting line position for horizontal/vertical lines.
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -264,7 +264,7 @@
           "orientation": {
             "type": "string",
             "title": "Orientation",
-            "description": "Orienta\u00e7\u00e3o do movimento do gado: N, NE, E, SE, S, SW, W, NW.\nEnglish: Orientation of cattle movement: N, NE, E, SE, S, SW, W, NW.",
+            "description": "Orienta\u00e7\u00e3o do movimento do gado: N, E, S, W.\nEnglish: Orientation of cattle movement: N, E, S, W.",
             "example": "S"
           },
           "model_choice": {

--- a/docs/pt/api-reference.md
+++ b/docs/pt/api-reference.md
@@ -58,7 +58,7 @@ Inicia o processamento de um vídeo previamente enviado.
 **Campos obrigatórios**
 
 - `nome_arquivo` (string): nome único do vídeo enviado.
-- `orientation` (`Orientation` enum): direção do movimento; valores possíveis: `N`, `NE`, `E`, `SE`, `S`, `SW`, `W`, `NW`. Use [`GET /orientation-map`](#get-orientation-map) para exibir essas opções na interface.
+- `orientation` (`Orientation` enum): direção do movimento; valores possíveis: `N`, `E`, `S`, `W`. Use [`GET /orientation-map`](#get-orientation-map) para exibir essas opções na interface.
 - `line_position_ratio` (número entre `0.0` e `1.0`, padrão `0.5`): posição da linha de contagem.
 
 **Campos opcionais**

--- a/orientation_map.json
+++ b/orientation_map.json
@@ -1,10 +1,6 @@
 {
   "N": {"label": "North", "arrow": "\u2191"},
-  "NE": {"label": "Northeast", "arrow": "\u2197"},
   "E": {"label": "East", "arrow": "\u2192"},
-  "SE": {"label": "Southeast", "arrow": "\u2198"},
   "S": {"label": "South", "arrow": "\u2193"},
-  "SW": {"label": "Southwest", "arrow": "\u2199"},
-  "W": {"label": "West", "arrow": "\u2190"},
-  "NW": {"label": "Northwest", "arrow": "\u2196"}
+  "W": {"label": "West", "arrow": "\u2190"}
 }

--- a/schemas.py
+++ b/schemas.py
@@ -11,13 +11,9 @@ class Orientation(str, Enum):
     """Allowed orientation codes."""
 
     N = "N"
-    NE = "NE"
     E = "E"
-    SE = "SE"
     S = "S"
-    SW = "SW"
     W = "W"
-    NW = "NW"
 
 
 class VideoRequest(BaseModel):
@@ -42,8 +38,8 @@ class VideoRequest(BaseModel):
         ...,
         example="S",
         description=(
-            "Orientação do movimento do gado: N, NE, E, SE, S, SW, W, NW.\n"
-            "English: Orientation of cattle movement: N, NE, E, SE, S, SW, W, NW."
+            "Orientação do movimento do gado: N, E, S, W.\n"
+            "English: Orientation of cattle movement: N, E, S, W."
         ),
     )
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -101,5 +101,6 @@ def test_orientation_map_endpoint_returns_map():
     response = client.get("/orientation-map")
     assert response.status_code == 200
     data = response.json()
+    assert set(data.keys()) == {"N", "E", "S", "W"}
     assert data["N"]["label"] == "North"
     assert data["S"]["arrow"] == "\u2193"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,6 @@
-"""Testes para utilidades de contagem de vídeo.
+"""Tests for video counting utilities.
 
-O módulo valida a configuração de linhas e direções e a detecção de
-cruzamentos de linhas diagonais.
-
-Tests for video counting utilities.
-
-The module validates line and direction configuration and detection of
-diagonal line crossings.
-"""
+The module validates line and direction configuration."""
 
 import subprocess
 from types import SimpleNamespace
@@ -18,11 +11,9 @@ import pytest
 from utils.contagem_video import (  # isort: skip
     LINE_VERTICAL,
     MOVE_LR,
-    MOVE_TL_BR,
     apply_rotation,
     get_line_and_direction_config,
     get_video_rotation,
-    is_crossing_diagonal_line,
 )
 
 
@@ -43,25 +34,6 @@ def test_get_line_and_direction_config_invalid_orientation():
 
     with pytest.raises(ValueError):
         get_line_and_direction_config("INVALID", width=100, height=50)
-
-
-def test_is_crossing_diagonal_line():
-    """Detect crossing of a top-left to bottom-right diagonal line."""
-
-    p_prev = (10, 20)
-    p_curr = (30, 25)
-    line_p1 = (0, 0)
-    line_p2 = (100, 100)
-    crossed = is_crossing_diagonal_line(
-        p_prev[0],
-        p_prev[1],
-        p_curr[0],
-        p_curr[1],
-        line_p1,
-        line_p2,
-        MOVE_TL_BR,
-    )
-    assert crossed is True
 
 
 def test_rotation_metadata_and_application(tmp_path, monkeypatch):

--- a/utils/contagem_video.py
+++ b/utils/contagem_video.py
@@ -15,17 +15,10 @@ logger = logging.getLogger(__name__)
 # --- Constantes para Clareza ---
 LINE_HORIZONTAL: str = "horizontal"
 LINE_VERTICAL: str = "vertical"
-LINE_DIAGONAL_FWD: str = "diag_fwd"
-LINE_DIAGONAL_BCK: str = "diag_bck"
-
 MOVE_TB: str = "top_bottom"
 MOVE_BT: str = "bottom_top"
 MOVE_LR: str = "left_right"
 MOVE_RL: str = "right_left"
-MOVE_TL_BR: str = "topleft_bottomright"
-MOVE_BR_TL: str = "bottomright_topleft"
-MOVE_TR_BL: str = "topright_bottomleft"
-MOVE_BL_TR: str = "bottomleft_topright"
 
 
 def get_video_rotation(video_path: str) -> int:
@@ -163,30 +156,6 @@ def get_line_and_direction_config(
             (line_pos_value + arrow_offset, height // 2),
             (line_pos_value - arrow_offset, height // 2),
         )
-    elif orientation_code == "SE":
-        line_type, effective_counting_direction = LINE_DIAGONAL_FWD, MOVE_TL_BR
-        line_points, arrow_points = ((0, 0), (width, height)), (
-            (width // 4, height // 4),
-            (3 * width // 4, 3 * height // 4),
-        )
-    elif orientation_code == "NW":
-        line_type, effective_counting_direction = LINE_DIAGONAL_FWD, MOVE_BR_TL
-        line_points, arrow_points = ((0, 0), (width, height)), (
-            (3 * width // 4, 3 * height // 4),
-            (width // 4, height // 4),
-        )
-    elif orientation_code == "NE":
-        line_type, effective_counting_direction = LINE_DIAGONAL_BCK, MOVE_BL_TR
-        line_points, arrow_points = ((0, height), (width, 0)), (
-            (width // 4, 3 * height // 4),
-            (3 * width // 4, height // 4),
-        )
-    elif orientation_code == "SW":
-        line_type, effective_counting_direction = LINE_DIAGONAL_BCK, MOVE_TR_BL
-        line_points, arrow_points = ((0, height), (width, 0)), (
-            (3 * width // 4, height // 4),
-            (width // 4, 3 * height // 4),
-        )
     else:
         msg = f"[AVISO get_line_config] Orientação '{orientation_code}' desconhecida."
         logger.warning(msg)
@@ -202,65 +171,6 @@ def get_line_and_direction_config(
         line_pos_value,
         arrow_points,
     )
-
-
-# !!! ATENÇÃO: ESTA FUNÇÃO PARA DETECÇÃO DIAGONAL É UM ESBOÇO CONCEITUAL. !!!
-def is_crossing_diagonal_line(
-    p_prev_x: int,
-    p_prev_y: int,
-    p_curr_x: int,
-    p_curr_y: int,
-    line_p1: Tuple[int, int],
-    line_p2: Tuple[int, int],
-    direction: str,
-) -> bool:
-    """Verifica se um objeto cruzou uma linha diagonal.
-
-    Check whether an object crossed a diagonal line.
-
-    Parâmetros / Parameters:
-        p_prev_x, p_prev_y (int): Coordenadas anteriores do objeto.
-            Previous object coordinates.
-        p_curr_x, p_curr_y (int): Coordenadas atuais do objeto.
-            Current object coordinates.
-        line_p1, line_p2 (Tuple[int, int]): Pontos que definem a linha.
-            Points that define the line.
-        direction (str): Direção esperada do cruzamento.
-            Expected crossing direction.
-
-    Retorno / Returns:
-        bool: ``True`` se o objeto cruzou na direção especificada, ``False`` caso contrário.
-        ``True`` if the object crossed in the expected direction, ``False`` otherwise.
-
-    Efeitos colaterais / Side Effects:
-        Nenhum.
-        None.
-
-    Exceções / Exceptions:
-        Nenhuma é lançada explicitamente.
-        None are explicitly raised.
-    """
-    (x1_line, y1_line), (x2_line, y2_line) = line_p1, line_p2
-    val_prev = (float(p_prev_y - y1_line) * (x2_line - x1_line)) - (
-        float(p_prev_x - x1_line) * (y2_line - y1_line)
-    )
-    val_curr = (float(p_curr_y - y1_line) * (x2_line - x1_line)) - (
-        float(p_curr_x - x1_line) * (y2_line - y1_line)
-    )
-    crossed = (val_prev < 0 and val_curr >= 0) or (val_prev > 0 and val_curr <= 0)
-    if not crossed:
-        return False
-    # Verificação de direção SIMPLIFICADA (precisa ser melhorada)
-    if direction == MOVE_TL_BR:
-        return p_curr_x > p_prev_x and p_curr_y > p_prev_y
-    elif direction == MOVE_BR_TL:
-        return p_curr_x < p_prev_x and p_curr_y < p_prev_y
-    elif direction == MOVE_BL_TR:
-        return p_curr_x > p_prev_x and p_curr_y < p_prev_y
-    elif direction == MOVE_TR_BL:
-        return p_curr_x < p_prev_x and p_curr_y > p_prev_y
-    return False
-
 
 def contar_gado_em_video(
     video_path: str,
@@ -536,22 +446,6 @@ def contar_gado_em_video(
                                 and curr_x <= line_coord_val
                             ):
                                 crossed = True
-                        elif (
-                            line_type.startswith("diag")
-                            and has_prev_pos
-                            and line_points is not None
-                        ):
-                            if is_crossing_diagonal_line(
-                                track_previous_x[track_id],
-                                track_previous_y[track_id],
-                                curr_x,
-                                curr_y,
-                                line_points[0],
-                                line_points[1],
-                                str(effective_counting_dir),
-                            ):
-                                crossed = True
-
                         if crossed and (
                             target_classes is None or nome_cls in target_classes
                         ):


### PR DESCRIPTION
## Summary
- limit orientation enum and request description to N/E/S/W
- drop diagonal orientation handling and update orientation map
- adjust tests and documentation for four cardinal directions only

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bee7fa4bec83218bc91d371fadc614