### PR TITLE
test: reject diagonal orientations

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -11,6 +11,7 @@ accepts videos with permitted extensions.
 
 import os
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -64,13 +65,14 @@ def test_upload_video_endpoint_accepts_valid_extension(tmp_path):
     assert saved_path.exists()
 
 
-def test_predict_video_endpoint_rejects_invalid_orientation():
-    """Return 400 when orientation code is invalid."""
+@pytest.mark.parametrize("orientation", ["INVALID", "NE"])
+def test_predict_video_endpoint_rejects_invalid_orientation(orientation):
+    """Return 400 when orientation code is invalid or diagonal."""
 
     client = TestClient(app)
     response = client.post(
         "/predict-video/",
-        json={"nome_arquivo": "video.mp4", "orientation": "INVALID"},
+        json={"nome_arquivo": "video.mp4", "orientation": orientation},
     )
     assert response.status_code == 400
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,12 +28,12 @@ def test_get_line_and_direction_config_east():
     assert line_points == ((50, 0), (50, 50))
     assert pos == 50
 
-
-def test_get_line_and_direction_config_invalid_orientation():
-    """Raise ValueError for unsupported orientation codes."""
+@pytest.mark.parametrize("orientation", ["NE", "NW", "SE", "SW"])
+def test_get_line_and_direction_config_invalid_orientation(orientation):
+    """Raise ValueError for unsupported diagonal orientation codes."""
 
     with pytest.raises(ValueError):
-        get_line_and_direction_config("NE", width=100, height=50)
+        get_line_and_direction_config(orientation, width=100, height=50)
 
 
 def test_rotation_metadata_and_application(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- ensure `predict-video` endpoint rejects diagonal orientations
- validate `get_line_and_direction_config` raises `ValueError` for diagonal inputs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bef74af1e88321aaf6b153831c4294